### PR TITLE
Experiments for deployment using PVC.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,7 +165,7 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/
 
 # Ruff stuff:
 .ruff_cache/

--- a/Containerfile
+++ b/Containerfile
@@ -2,5 +2,7 @@ ARG LLAMA_STACK_VERSION=0.2.7
 FROM ansible-chatbot:${LLAMA_STACK_VERSION}
 
 RUN mkdir -p /.llama/distributions/ansible-chatbot
-ADD aap_faiss_store.db /.llama/distributions/ansible-chatbot
 ADD ansible-chatbot-run.yaml /.llama/distributions/ansible-chatbot
+
+RUN mkdir -p /.llama/data/ansible-chatbot
+ADD aap_faiss_store.db /.llama/data/distributions/ansible-chatbot

--- a/Containerfile
+++ b/Containerfile
@@ -6,3 +6,11 @@ ADD ansible-chatbot-run.yaml /.llama/distributions/ansible-chatbot
 
 RUN mkdir -p /.llama/data/ansible-chatbot
 ADD aap_faiss_store.db /.llama/data/distributions/ansible-chatbot
+
+# Temporary workaround for k8s deployments
+# We mount a PVC at /.llama/data and so the above _copy_ is hidden, masked by the PVC mount
+# When the container starts we copy this temp file to the PVC
+RUN mkdir -p /.llama/temp
+ADD bootstrap.sh /.llama/temp
+RUN chmod +x /.llama/temp/bootstrap.sh
+ADD aap_faiss_store.db /.llama/temp

--- a/ansible-chatbot-deploy.yaml
+++ b/ansible-chatbot-deploy.yaml
@@ -55,7 +55,7 @@ spec:
         envFrom:
           - configMapRef:
               name: "ansible-chatbot-server-env-properties"
-        command: ["python", "-m", "llama_stack.distribution.server.server", "--config", "/.llama/distributions/ansible-chatbot/ansible-chatbot-run.yaml"]
+        command: ["/bin/bash", "/.llama/temp/bootstrap.sh"]
         ports:
           - containerPort: 8321
         volumeMounts:

--- a/ansible-chatbot-deploy.yaml
+++ b/ansible-chatbot-deploy.yaml
@@ -47,17 +47,20 @@ spec:
       containers:
       - name: ansible-chatbot
         # TODO: Just using a temporal container. Change it to the final one, with access controls.
-        image: quay.io/romartin/ansible-chatbot:aap-0.2.7
+        image: quay.io/manstis/ansible-chatbot:aap-0.2.7
         imagePullPolicy: IfNotPresent
+        env:
+          - name: LLAMA_STACK_CONFIG_DIR
+            value: /.llama/data/
         envFrom:
           - configMapRef:
               name: "ansible-chatbot-server-env-properties"
         command: ["python", "-m", "llama_stack.distribution.server.server", "--config", "/.llama/distributions/ansible-chatbot/ansible-chatbot-run.yaml"]
         ports:
-          - containerPort: 5000
+          - containerPort: 8321
         volumeMounts:
           - name: ansible-chatbot-storage
-            mountPath: /root/.llama
+            mountPath: /.llama/data
       volumes:
       - name: ansible-chatbot-storage
         persistentVolumeClaim:

--- a/ansible-chatbot-run.yaml
+++ b/ansible-chatbot-run.yaml
@@ -28,7 +28,7 @@ providers:
       kvstore:
         type: sqlite
         namespace: null
-        db_path: ${env.SQLITE_STORE_DIR:/.llama/distributions/ansible-chatbot}/aap_faiss_store.db
+        db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/aap_faiss_store.db
   safety:
   - provider_id: llama-guard
     provider_type: inline::llama-guard
@@ -75,7 +75,7 @@ providers:
       persistence_store:
         type: sqlite
         namespace: null
-        db_path: ${env.SQLITE_STORE_DIR:/.llama/distributions/ansible-chatbot}/agents_store.db
+        db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/agents_store.db
   datasetio:
   - provider_id: localfs
     provider_type: inline::localfs
@@ -83,14 +83,14 @@ providers:
       kvstore:
         type: sqlite
         namespace: null
-        db_path: ${env.SQLITE_STORE_DIR:/.llama/distributions/ansible-chatbot}/localfs_datasetio.db
+        db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/localfs_datasetio.db
   telemetry:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
       service_name: ${env.OTEL_SERVICE_NAME:}
       sinks: ${env.TELEMETRY_SINKS:console,sqlite}
-      sqlite_db_path: ${env.SQLITE_STORE_DIR:/.llama/distributions/ansible-chatbot}/trace_store.db
+      sqlite_db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/trace_store.db
   tool_runtime:
   - provider_id: rag-runtime
     provider_type: inline::rag-runtime

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,5 @@
+# Copy RAG database to PVC
+cp /.llama/temp/aap_faiss_store.db /.llama/data/distributions/ansible-chatbot
+
+# Start llama-stack server
+python -m llama_stack.distribution.server.server --config /.llama/distributions/ansible-chatbot/ansible-chatbot-run.yaml


### PR DESCRIPTION
@romartin FYI.

I mount the PVC on `/.llama/data`

The `llama-stack` databases are expected to be at `/.llama/data/distributions/ansible-chatbot` i.e. _in_ the PVC.

`llama-stack` tries to create `kvstore.db` when parsing the run-config file. It tries to write it to `~/.llama/.....`

I override this with the environment variable `LLAMA_STACK_CONFIG_DIR` set to `/.llama/data/` i.e. _in_ the PVC.

I cannot remove use of `distributions` as `llama-stack` hard-codes this lead onto `LLAMA_STACK_CONFIG_DIR`.

The run-config file still lives in `/.llama/distributions/ansible-chatbot/ansible-chatbot-run.yaml` i.e. *NOT* _in_ the PVC.

I tried copying the `aap_faiss.db` to `/.llama/data/distributions/ansible-chatbot` with the `Containerfile`.

I assume however that mounting the PVC at `/.llama/data` _hides_ the database file.

We'll need to copy it to a path not in the PVC and then move it to the PVC before starting `llama-stack`.

