### PR TITLE
Fixes for AAP database handling.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,9 +4,6 @@ FROM ansible-chatbot:${LLAMA_STACK_VERSION}
 RUN mkdir -p /.llama/distributions/ansible-chatbot
 ADD ansible-chatbot-run.yaml /.llama/distributions/ansible-chatbot
 
-RUN mkdir -p /.llama/data/ansible-chatbot
-ADD aap_faiss_store.db /.llama/data/distributions/ansible-chatbot
-
 # Temporary workaround for k8s deployments
 # We mount a PVC at /.llama/data and so the above _copy_ is hidden, masked by the PVC mount
 # When the container starts we copy this temp file to the PVC
@@ -14,3 +11,5 @@ RUN mkdir -p /.llama/temp
 ADD bootstrap.sh /.llama/temp
 RUN chmod +x /.llama/temp/bootstrap.sh
 ADD aap_faiss_store.db /.llama/temp
+
+ENTRYPOINT ["/bin/sh", "/.llama/temp/bootstrap.sh"]

--- a/README.md
+++ b/README.md
@@ -104,9 +104,13 @@ flowchart TB
 
 ## Deploy into a k8s cluster
 
+0.- Change configuration in `kustomization.yaml` accordingly, then:
+
+    kubectl kustomize . > my-chatbot-stack-deploy.yaml
+
 1.- Deploy the service:
 
-    kubectl apply -f ansible-chatbot-deploy.yaml
+    kubectl apply -f my-chatbot-stack-deploy.yaml
 
 2.- [Verify the deployment](https://llama-stack.readthedocs.io/en/latest/distributions/kubernetes_deployment.html#verifying-the-deployment)
 

--- a/ansible-chatbot-deploy.yaml
+++ b/ansible-chatbot-deploy.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: ansible-chatbot-pvc
-  # TODO: Use proper value or delete namespace here.
-  namespace: romartin-chatbot-stack
 spec:
   accessModes:
     - ReadWriteOnce
@@ -16,8 +14,6 @@ kind: ConfigMap
 apiVersion: v1
 metadata:
   name: ansible-chatbot-server-env-properties
-  # TODO: Use proper value or delete namespace here.
-  namespace: romartin-chatbot-stack
 immutable: false
 data:
   ANSIBLE_CHATBOT_IMAGE_TAG: "aap-0.2.7"
@@ -32,8 +28,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ansible-chatbot-server
-  # TODO: Use proper value or delete namespace here.
-  namespace: romartin-chatbot-stack
 spec:
   replicas: 1
   selector:
@@ -44,10 +38,11 @@ spec:
       labels:
         app.kubernetes.io/name: ansible-chatbot
     spec:
+      imagePullSecrets:
+      - name: quay-pull-secret
       containers:
       - name: ansible-chatbot
-        # TODO: Just using a temporal container. Change it to the final one, with access controls.
-        image: quay.io/manstis/ansible-chatbot:aap-0.2.7
+        image: ansible-chatbot:aap-0.2.7
         imagePullPolicy: IfNotPresent
         env:
           - name: LLAMA_STACK_CONFIG_DIR
@@ -55,7 +50,6 @@ spec:
         envFrom:
           - configMapRef:
               name: "ansible-chatbot-server-env-properties"
-        command: ["/bin/bash", "/.llama/temp/bootstrap.sh"]
         ports:
           - containerPort: 8321
         volumeMounts:
@@ -70,8 +64,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ansible-chatbot-service
-  # TODO: Use proper value or delete namespace here.
-  namespace: romartin-chatbot-stack
 spec:
   selector:
     app.kubernetes.io/name: ansible-chatbot

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,5 @@
 # Copy RAG database to PVC
+mkdir -p /.llama/data/distributions/ansible-chatbot
 cp /.llama/temp/aap_faiss_store.db /.llama/data/distributions/ansible-chatbot
 
 # Start llama-stack server

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ansible-chatbot-deploy.yaml
+namespace: ansible-chatbot-stack
+images:
+- name: ansible-chatbot
+  newName: quay.io/ansible/ansible-chatbot
+  newTag: aap-0.2.7


### PR DESCRIPTION
Hey @manstis 

This is a follow up for [this conversation](https://github.com/ansible/ansible-chatbot-stack/pull/6#issuecomment-2932279030).

My ideal should be something like what proposed on this PR. It now works on _local_ `docker`, but does NOT work on `Minikube` :( ( Not tested on Openshift yet. )
 
I will continue my research, but the problem now is that once running the stack, at least when using local `docker` way, it downloads at runtime the model `all-MiniLM-L6-v2 `, but for `Minikube` it complains the model just doesn't exist. Will continue tomorrow...

Anyway, I think we should assume anyway the model `all-MiniLM-L6-v2` is self-contained in the image. WDYT??

Thx