### PR TITLE
Use ubi9 as base image

### DIFF
--- a/ansible-chatbot-build.yaml
+++ b/ansible-chatbot-build.yaml
@@ -32,6 +32,7 @@ distribution_spec:
 #    - remote::model-context-protocol
     - remote::lightspeed
 #    - remote::wolfram-alpha
+  container_image: "registry.access.redhat.com/ubi9"
 image_name: ansible-chatbot
 image_type: container
 


### PR DESCRIPTION
Use ubi9 as base image (default is ubuntu-latest).  

Reference: https://github.com/meta-llama/llama-stack/pull/676