### PR TITLE
Copy vector db to PVC

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,5 @@ ADD ansible-chatbot-run.yaml /.llama/distributions/ansible-chatbot
 RUN mkdir -p /.llama/temp
 ADD bootstrap.sh /.llama/temp
 RUN chmod +x /.llama/temp/bootstrap.sh
-ADD aap_faiss_store.db /.llama/temp
 
 ENTRYPOINT ["/bin/sh", "/.llama/temp/bootstrap.sh"]

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ flowchart TB
 > The value for env `PYPI_VERSION` specifies the concrete llama-stack release to use, once building the ansible-chatbot distribution (image). 
 
     export PYPI_VERSION=0.2.9
-    export LLAMA_STACK_LOGGING=server=debug;core=info
+    export LLAMA_STACK_LOGGING='server=debug;core=info'
     export UV_HTTP_TIMEOUT=120
     llama stack build --config ansible-chatbot-build.yaml --image-type container
 

--- a/ansible-chatbot-build.yaml
+++ b/ansible-chatbot-build.yaml
@@ -35,5 +35,8 @@ distribution_spec:
   container_image: "registry.access.redhat.com/ubi9"
 image_name: ansible-chatbot
 image_type: container
+additional_pip_packages:
+- aiosqlite
+- sqlalchemy[asyncio]
 
 external_providers_dir: ~/.llama/providers.d

--- a/ansible-chatbot-deploy.yaml
+++ b/ansible-chatbot-deploy.yaml
@@ -56,6 +56,39 @@ spec:
         volumeMounts:
           - name: ansible-chatbot-storage
             mountPath: /.llama/data
+      initContainers:
+      - name: init-rag-vector-db
+        image: quay.io/ansible/aap-rag-content:latest
+        command:
+        - /bin/bash
+        - -c
+        - |
+          echo "Initialize RAG vector database"
+          MOUNTPATH=/.llama/data
+          if [[ ! -d ${MOUNTPATH} ]]; then
+            echo "Volume mount path is not found."
+            exit 1
+          fi
+          DESTDIR=${MOUNTPATH}/distributions/ansible-chatbot
+          mkdir -p ${DESTDIR}
+          cd /rag/llama_stack_vector_db
+          diff faiss_store.db.gz.sha256 ${DESTDIR}/faiss_store.db.gz.sha256
+          if [[ $? != 0 ]]; then
+            gzip -cd faiss_store.db.gz > ${DESTDIR}/aap_faiss_store.db
+            if [[ $? != 0 ]]; then
+              echo "Failed to install new vector database file."
+              exit 1
+            fi
+            cp faiss_store.db.gz.sha256 ${DESTDIR}
+            echo "Latest vector database file has been installed."
+          else
+            echo "Latest vector database file already up-to-date and installed.."
+          fi
+          ls -l ${DESTDIR}/aap_faiss_store.db
+          cat ${DESTDIR}/faiss_store.db.gz.sha256
+        volumeMounts:
+          - name: ansible-chatbot-storage
+            mountPath: /.llama/data
       volumes:
       - name: ansible-chatbot-storage
         persistentVolumeClaim:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,6 +1,2 @@
-# Copy RAG database to PVC
-mkdir -p /.llama/data/distributions/ansible-chatbot
-cp /.llama/temp/aap_faiss_store.db /.llama/data/distributions/ansible-chatbot
-
 # Start llama-stack server
 python -m llama_stack.distribution.server.server --config /.llama/distributions/ansible-chatbot/ansible-chatbot-run.yaml


### PR DESCRIPTION
For [AAP-47116](https://issues.redhat.com/browse/AAP-47116).

Copy vector db from `quay.io/ansible/aap-rag-content:latest` using `initContainers`.  If the same vector DB file was already installed, it does not attempt to override the existing DB file.