### PR TITLE
Use pre-loaded embeddings model

### DIFF
--- a/ansible-chatbot-deploy.yaml
+++ b/ansible-chatbot-deploy.yaml
@@ -48,6 +48,8 @@ spec:
         env:
           - name: LLAMA_STACK_CONFIG_DIR
             value: /.llama/data/
+          - name: EMBEDDING_MODEL
+            value: /.llama/data/embeddings_model
         envFrom:
           - configMapRef:
               name: "ansible-chatbot-server-env-properties"
@@ -82,10 +84,25 @@ spec:
             cp faiss_store.db.gz.sha256 ${DESTDIR}
             echo "Latest vector database file has been installed."
           else
-            echo "Latest vector database file already up-to-date and installed.."
+            echo "Latest vector database file already up-to-date and installed."
           fi
           ls -l ${DESTDIR}/aap_faiss_store.db
           cat ${DESTDIR}/faiss_store.db.gz.sha256
+          echo "Initialize embedding model"
+          cd /rag
+          diff embeddings_model/config.json ${MOUNTPATH}/embeddings_model/config.json
+          if [[ $? != 0 ]]; then
+            rm -rf ${MOUNTPATH}/embeddings_model
+            cp -r embeddings_model ${MOUNTPATH}
+            if [[ $? != 0 ]]; then
+              echo "Failed to install embedding model."
+              exit 1
+            fi
+            echo "Latest embeddings model has been installed."
+          else
+            echo "Latest embeddings model already up-to-date and installed."
+          fi
+          cat ${MOUNTPATH}/embeddings_model/config.json
         volumeMounts:
           - name: ansible-chatbot-storage
             mountPath: /.llama/data

--- a/ansible-chatbot-run.yaml
+++ b/ansible-chatbot-run.yaml
@@ -109,8 +109,8 @@ models:
   provider_id: rhosai_vllm_dev
   provider_model_id: null
 - metadata:
-    embedding_dimension: 384
-  model_id: all-MiniLM-L6-v2
+    embedding_dimension: 768
+  model_id: ${env.EMBEDDING_MODEL:all-mpnet-base-v2}
   provider_id: inline_sentence-transformer
   model_type: embedding
 shields: []
@@ -119,8 +119,8 @@ shields: []
 vector_dbs:
 - metadata: {}
   vector_db_id: "aap-product-docs-2_5"
-  embedding_model: "all-MiniLM-L6-v2"
-  embedding_dimension: 384
+  embedding_model: ${env.EMBEDDING_MODEL:all-mpnet-base-v2}
+  embedding_dimension: 768
   provider_id: "aap_faiss"
 datasets: []
 scoring_fns: []


### PR DESCRIPTION
For [AAP-47230](https://issues.redhat.com/browse/AAP-47230).

Copy the embedding model (`all-mpnet-base-v2`) stored in the vector db container image to PVC. It is the same model as the one used in our road-core based chatbot service implementation.

Note: The directory name is set to `embeddings_model`, instead of `embedding_model`.  It is simply because the original OLS code (`openshift-rag-content`) named the directory in that way. We can change it to whatever we want, but I kept it the original name for now.