### PR TITLE
Create a symlink for setting EMBEDDING_MODEL to ./embeddings_model

### DIFF
--- a/ansible-chatbot-deploy.yaml
+++ b/ansible-chatbot-deploy.yaml
@@ -49,7 +49,7 @@ spec:
           - name: LLAMA_STACK_CONFIG_DIR
             value: /.llama/data/
           - name: EMBEDDING_MODEL
-            value: /.llama/data/embeddings_model
+            value: ./embeddings_model
         envFrom:
           - configMapRef:
               name: "ansible-chatbot-server-env-properties"
@@ -58,6 +58,13 @@ spec:
         volumeMounts:
           - name: ansible-chatbot-storage
             mountPath: /.llama/data
+        command:
+          - /bin/bash
+          - -c
+          - |
+            ln -s /.llama/data/embeddings_model ./embeddings_model
+            python -m llama_stack.distribution.server.server --config /.llama/distributions/ansible-chatbot/ansible-chatbot-run.yaml
+
       initContainers:
       - name: init-rag-vector-db
         image: quay.io/ansible/aap-rag-content:latest


### PR DESCRIPTION
Current aap-rag-content build creates the vector DB using the pre-loaded model stored in `./embeddings_model`.
The string ./embeddings_model` seems to be stored in the vector DB and the runtime code checks if the path exists or not. So we need to create the path and set the embedding model at `./embeddings_model`.

This PR let the `ansible-chatbot-stack` container to create a symlink and set `EMBEDDING_MODEL` envvar to the created symlink to resolve the issue.