### PR TITLE
Bump MCP servers to 0.0.2 and fix kustomization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,3 +178,4 @@ agents_store.db
 localfs_datasetio.db
 responses_store.db
 trace_store.db
+/embeddings_model

--- a/ansible-chatbot-deploy.yaml
+++ b/ansible-chatbot-deploy.yaml
@@ -56,7 +56,7 @@ spec:
             - /rag/entrypoint.sh
       containers:
       - name: ansible-chatbot
-        image: quay.io/ansible/ansible-chatbot-stack:0.0.2
+        image: ansible-chatbot-stack
         imagePullPolicy: IfNotPresent
         env:
           - name: LLAMA_STACK_CONFIG_DIR
@@ -72,7 +72,7 @@ spec:
           - name: ansible-chatbot-storage
             mountPath: /.llama/data
       - name: ansible-mcp-gateway
-        image: quay.io/ansible/ansible-mcp-gateway:0.0.1
+        image: ansible-mcp-gateway
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8003
@@ -86,7 +86,7 @@ spec:
           - name: PORT
             value: '8003'
       - name: ansible-mcp-controller
-        image: quay.io/ansible/ansible-mcp-controller:0.0.1
+        image: ansible-mcp-controller
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8004
@@ -105,7 +105,7 @@ spec:
                 name: "ansible-chatbot-server-env-properties"
                 key: AAP_CONTROLLER_SERVICE_URL
       - name: ansible-mcp-lightspeed
-        image: quay.io/ansible/ansible-mcp-lightspeed:0.0.1
+        image: ansible-mcp-lightspeed
         imagePullPolicy: IfNotPresent
         ports:
           - containerPort: 8005

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -4,6 +4,15 @@ resources:
 - ansible-chatbot-deploy.yaml
 namespace: ansible-chatbot-stack
 images:
-- name: ansible-chatbot
+- name: ansible-chatbot-stack
   newName: quay.io/ansible/ansible-chatbot-stack
-  newTag: 0.0.1
+  newTag: 0.0.2
+- name: ansible-mcp-gateway
+  newName: quay.io/ansible/ansible-mcp-gateway
+  newTag: 0.0.2
+- name: ansible-mcp-controller
+  newName: quay.io/ansible/ansible-mcp-controller
+  newTag: 0.0.2
+- name: ansible-mcp-lightspeed
+  newName: quay.io/ansible/ansible-mcp-lightspeed
+  newTag: 0.0.2


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Bump MCP Server versions to `0.0.2`

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
