### PR TITLE
Bump ansible-chatbot-stack to 0.0.3

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: ansible-chatbot-stack
 images:
 - name: ansible-chatbot-stack
   newName: quay.io/ansible/ansible-chatbot-stack
-  newTag: 0.0.2
+  newTag: 0.0.3
 - name: ansible-mcp-gateway
   newName: quay.io/ansible/ansible-mcp-gateway
   newTag: 0.0.2


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
A newer version of `ansible-chatbot-stack` was pushed to quay.io, `0.0.3`.

This version supports the additional environment variables for MCP support.

## Testing
Deploy `ansible-chatbot-stack:0.0.3` somewhere (using [this](https://github.com/ansible/ansible-chatbot-stack/blob/main/ansible-chatbot-deploy.yaml)) with MCP related environment variables set.

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
