### PR TITLE
AAP-47674: ansible-chatbot-stack should run as non-root user

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,12 +1,22 @@
 ARG ANSIBLE_CHATBOT_BASE_IMAGE=ansible-chatbot-stack-base
 ARG LLAMA_STACK_VERSION=0.2.9
+
 FROM ${ANSIBLE_CHATBOT_BASE_IMAGE}:${LLAMA_STACK_VERSION}
 
-RUN mkdir -p /.llama/distributions/ansible-chatbot
-ADD ansible-chatbot-run.yaml /.llama/distributions/ansible-chatbot
+ENV LLAMA_STACK_CONFIG_DIR=/.llama/data
 
+# Data and configuration
+RUN mkdir -p /.llama/distributions/ansible-chatbot
+RUN mkdir -p /.llama/data/distributions/ansible-chatbot
+ADD ansible-chatbot-run.yaml /.llama/distributions/ansible-chatbot
+RUN chmod -R g+rw /.llama
+
+# Bootstrap
 RUN mkdir -p /.llama/temp
 ADD entrypoint.sh /.llama/temp
 RUN chmod +x /.llama/temp/entrypoint.sh
+
+# See https://github.com/meta-llama/llama-stack/issues/1633
+# USER 1000
 
 ENTRYPOINT ["/.llama/temp/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -58,10 +58,8 @@ setup: setup-vector-db
 	python3 -m venv venv
 	. venv/bin/activate && pip install -r requirements.txt
 	mkdir -p ~/.llama/providers.d/inline/agents/
-	mkdir -p ~/.llama/providers.d/inline/safety/
 	mkdir -p ~/.llama/providers.d/remote/tool_runtime/
 	curl -o ~/.llama/providers.d/inline/agents/lightspeed_inline_agent.yaml https://raw.githubusercontent.com/lightspeed-core/lightspeed-providers/refs/heads/main/resources/external_providers/inline/agents/lightspeed_inline_agent.yaml
-	curl -o ~/.llama/providers.d/inline/safety/lightspeed_question_validity.yaml https://raw.githubusercontent.com/lightspeed-core/lightspeed-providers/refs/heads/main/resources/external_providers/inline/safety/lightspeed_question_validity.yaml
 	curl -o ~/.llama/providers.d/remote/tool_runtime/lightspeed.yaml https://raw.githubusercontent.com/lightspeed-core/lightspeed-providers/refs/heads/main/resources/external_providers/remote/tool_runtime/lightspeed.yaml
 	@echo "Environment setup complete."
 

--- a/ansible-chatbot-build.yaml
+++ b/ansible-chatbot-build.yaml
@@ -7,31 +7,17 @@ distribution_spec:
     - inline::sentence-transformers
     vector_io:
     - inline::faiss
-#    - remote::chromadb
-#    - remote::pgvector
     safety:
     - inline::llama-guard
-    - inline::lightspeed_question_validity
     agents:
     - inline::meta-reference
-#    eval:
-#    - inline::meta-reference
     datasetio:
-#    - remote::huggingface
     - inline::localfs
-#    scoring:
-#    - inline::basic
-#    - inline::llm-as-judge
-#    - inline::braintrust
     telemetry:
     - inline::meta-reference
     tool_runtime:
     - inline::rag-runtime
-#    - remote::brave-search
-#    - remote::tavily-search
-#    - remote::model-context-protocol
     - remote::lightspeed
-#    - remote::wolfram-alpha
   container_image: "registry.access.redhat.com/ubi9"
 image_name: ansible-chatbot-stack-base
 image_type: container

--- a/ansible-chatbot-run.yaml
+++ b/ansible-chatbot-run.yaml
@@ -28,7 +28,7 @@ providers:
       kvstore:
         type: sqlite
         namespace: null
-        db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/aap_faiss_store.db
+        db_path: /.llama/data/distributions/ansible-chatbot/aap_faiss_store.db
   safety:
   - provider_id: llama-guard
     provider_type: inline::llama-guard
@@ -41,18 +41,14 @@ providers:
       persistence_store:
         type: sqlite
         namespace: null
-        db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/agents_store.db
+        db_path: /.llama/data/distributions/ansible-chatbot/agents_store.db
       responses_store:
         type: sqlite
         namespace: null
-        db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/responses_store.db
+        db_path: /.llama/data/distributions/ansible-chatbot/responses_store.db
       tools_filter:
         enabled: true
         model_id: ${env.INFERENCE_MODEL_FILTER:}
-      toolgroups:
-        - "mcp::aap-gateway"
-        - "mcp::aap-controller"
-        - "mcp::aap-lightspeed"
   datasetio:
   - provider_id: localfs
     provider_type: inline::localfs
@@ -60,14 +56,14 @@ providers:
       kvstore:
         type: sqlite
         namespace: null
-        db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/localfs_datasetio.db
+        db_path: /.llama/data/distributions/ansible-chatbot/localfs_datasetio.db
   telemetry:
   - provider_id: meta-reference
     provider_type: inline::meta-reference
     config:
       service_name: ${env.OTEL_SERVICE_NAME:}
       sinks: ${env.TELEMETRY_SINKS:console,sqlite}
-      sqlite_db_path: ${env.SQLITE_STORE_DIR:/.llama/data/distributions/ansible-chatbot}/trace_store.db
+      sqlite_db_path: /.llama/data/distributions/ansible-chatbot/trace_store.db
   tool_runtime:
   - provider_id: rag-runtime
     provider_type: inline::rag-runtime
@@ -84,32 +80,20 @@ models:
   provider_model_id: null
 - metadata:
     embedding_dimension: 768
-  model_id: ${env.EMBEDDING_MODEL:./embeddings_model}
+  model_id: ./embeddings_model
   provider_id: inline_sentence-transformer
   model_type: embedding
 shields: []
 vector_dbs:
 - metadata: {}
   vector_db_id: "aap-product-docs-2_5"
-  embedding_model: ${env.EMBEDDING_MODEL:./embeddings_model}
+  embedding_model: ./embeddings_model
   embedding_dimension: 768
   provider_id: "aap_faiss"
 datasets: []
 scoring_fns: []
 benchmarks: []
 tool_groups:
-  - toolgroup_id: "mcp::aap-gateway"
-    provider_id: lightspeed
-    mcp_endpoint:
-      uri: "http://127.0.0.1:8003/sse"
-  - toolgroup_id: "mcp::aap-controller"
-    provider_id: lightspeed
-    mcp_endpoint:
-      uri: "http://127.0.0.1:8004/sse"
-  - toolgroup_id: "mcp::aap-lightspeed"
-    provider_id: lightspeed
-    mcp_endpoint:
-      uri: "http://127.0.0.1:8005/sse"
   - toolgroup_id: builtin::rag
     provider_id: rag-runtime
 logging: null


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-47674

## Description
This JIRA was intending to allow the `llama-stack` to run as a non-root user.

This works fine for `docker run...` locally; however it still fails on k8s.

The reason being https://github.com/meta-llama/llama-stack/issues/1633 which appears to be a permissions issue.

I've tried and tried to resolve it; however it's not clear what the cause is.

Therefore this PR adds _most_ of the work to run as non-root.. but ultimately falls short.

It contains some tidy-up to remove automatic registration of the MCP servers; as it prevents running the stack locally.

## Testing
```
make build-custom
make run
```

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
