### PR TITLE
Remove AAP_GATEWAY_TOKEN env var

### DIFF
--- a/ansible-chatbot-run.yaml
+++ b/ansible-chatbot-run.yaml
@@ -70,8 +70,7 @@ providers:
     config: {}
   - provider_id: lightspeed
     provider_type: remote::lightspeed
-    config:
-      api_key: ${env.AAP_GATEWAY_TOKEN}
+    config: {}
 metadata_store: null
 models:
 - metadata: {}


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
MCP server declaration/configuration was removed (in `0.0.4`) however the `AAP_GATEWAY_TOKEN` remained.

## Testing
Attempt to run a _vanilla_ `ansible-chatbot-stack` container without setting `AAP_GATEWAY_TOKEN`.

This should be possible as the env var is only required for MCP servers (not using User JWT token authentication).

### Steps to test
1. Pull down the PR
2. `make build-custom`, `make run` without setting `AAP_GATEWAY_TOKEN`.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
