### PR TITLE
Bump lightspeed-stack-providers to 0.1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 llama-stack==0.2.9
 llama-stack-client==0.2.9
 fire==0.7.0
-lightspeed_stack_providers==0.1.4
+lightspeed_stack_providers==0.1.5


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Bump the version of `lightspeed-stack-providers` to `0.1.5` for the enhanced authentication header support.

## Testing
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
