### PR TITLE
Bump ansible-chatbot-stack to 0.0.6

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: ansible-chatbot-stack
 images:
 - name: ansible-chatbot-stack
   newName: quay.io/ansible/ansible-chatbot-stack
-  newTag: 0.0.3
+  newTag: 0.0.6
 - name: ansible-mcp-gateway
   newName: quay.io/ansible/ansible-mcp-gateway
   newTag: 0.0.2


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Bump the version of `ansible-chatbot-stack` to `0.0.6`

`0.0.6` will be available when https://github.com/ansible/ansible-chatbot-stack/actions/runs/15737080679 completes.

## Testing
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
