### PR TITLE
Bump ansible-chatbot-stack to 'latest'.

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -6,7 +6,7 @@ namespace: ansible-chatbot-stack
 images:
 - name: ansible-chatbot-stack
   newName: quay.io/ansible/ansible-chatbot-stack
-  newTag: 0.0.6
+  newTag: latest
 - name: ansible-mcp-gateway
   newName: quay.io/ansible/ansible-mcp-gateway
   newTag: 0.0.2


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Following the [change](https://github.com/ansible/ansible-chatbot-stack/pull/40) to `build_and_deploy.yml` this PR simply sets the `ansible-chatbot-stack` version to `latest`.

## Testing
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
