### PR TITLE
Fixes for llama-stack 0.2.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 llama-stack==0.2.12
 llama-stack-client==0.2.12
 fire==0.7.0
-lightspeed_stack_providers==0.1.5
+lightspeed_stack_providers==0.1.8


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Bump version of `lightspeed-stack-providers` to `0.1.8` following fixes therein for `llama-stack` version `0.2.12`.

`lightspeed-stack-providers` published here: https://pypi.org/project/lightspeed-stack-providers/

## Testing
```
make setup
make build-custom
make run
```

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
