### PR TITLE
Externalise lightspeed-stack.yaml configuration file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,7 @@ run-lsc: check-env-run
 	docker run --security-opt label=disable -it -p $(LLAMA_STACK_PORT):8080 \
 	  -v ./embeddings_model:/.llama/data/embeddings_model \
 	  -v ./vector_db/aap_faiss_store.db:$(CONTAINER_DB_PATH)/aap_faiss_store.db \
+	  -v ./lightspeed-stack/lightspeed-stack.yaml:/.llama/data/lightspeed-stack.yaml \
 	  --env VLLM_URL=$(ANSIBLE_CHATBOT_VLLM_URL) \
 	  --env VLLM_API_TOKEN=$(ANSIBLE_CHATBOT_VLLM_API_TOKEN) \
 	  --env INFERENCE_MODEL=$(ANSIBLE_CHATBOT_INFERENCE_MODEL) \

--- a/lightspeed-stack/Containerfile.lsc
+++ b/lightspeed-stack/Containerfile.lsc
@@ -61,9 +61,6 @@ ADD ansible-chatbot-run.yaml /.llama/distributions/ansible-chatbot
 ADD llama-stack/providers.d /.llama/providers.d
 RUN chmod -R g+rw /.llama
 
-# lightspeed-core
-ADD lightspeed-stack/lightspeed-stack.yaml /app-root/lightspeed-stack.yaml
-
 # Bootstrap
 ADD lightspeed-stack/entrypoint.sh /.llama
 RUN chmod +x /.llama/entrypoint.sh

--- a/lightspeed-stack/entrypoint.sh
+++ b/lightspeed-stack/entrypoint.sh
@@ -23,4 +23,4 @@ else
   fi
 fi
 
-python3.11 src/lightspeed_stack.py
+python3.11 src/lightspeed_stack.py --config /.llama/data/lightspeed-stack.yaml


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Move the `lightspeed-stack.yaml` configuration file out of the container image.

This will allow the Lightspeed Operator to construct the file and mount it on the PVC.

## Testing
```
export ANSIBLE_CHATBOT_VERSION=0.0.1-alpha
make build-lsc

export ANSIBLE_CHATBOT_INFERENCE_MODEL=<model>
export ANSIBLE_CHATBOT_VLLM_URL=<url>
export ANSIBLE_CHATBOT_VLLM_API_TOKEN=<token>
make run-lsc

make run-test-lsc
```

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
