### PR TITLE
Fixing the clean - setup make procedure.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,7 +199,7 @@ run-local-db: check-env-run-local-db
 clean:
 	@echo "Cleaning up..."
 	@echo "Cleaning up your local folders..."
-	rm -rf ~/.llama/*
+	rm -rf llama-stack/
 	rm -rf providers.d/
 	@echo "Removing ansible-chatbot-stack images..."
 	docker rmi -f $$(docker images -a -q --filter reference=ansible-chatbot-stack) || true

--- a/ansible-chatbot-build.yaml
+++ b/ansible-chatbot-build.yaml
@@ -26,4 +26,4 @@ additional_pip_packages:
 - sqlalchemy[asyncio]
 - numpy==2.2.6
 
-external_providers_dir: ~/.llama/providers.d
+external_providers_dir: ./llama-stack/providers.d


### PR DESCRIPTION
Just noticed after doing a `make clean`, the `make setup` fails.

This is due to the make setup is generating the `providers.d/` folder inside a generated `llama-stack/` root folder, so the clean and the llama-stack build yaml are updated to just use this llama-stack/` one. 

I think this way we don't mess-up with local (host) installations on the `.llama/` home's path. We just generate a local one, and use it for the build, once cleaning, this local one is deleted.