### PR TITLE
Install jq to support easier parsing of ansible-chatbot-version-info.json

### DIFF
--- a/lightspeed-stack/Containerfile.lsc
+++ b/lightspeed-stack/Containerfile.lsc
@@ -36,7 +36,7 @@ USER 0
 # Re-declaring arguments without a value, inherits the global default one.
 ARG ANSIBLE_CHATBOT_VERSION
 ARG APP_ROOT=/app-root
-RUN microdnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs python3.11
+RUN microdnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs python3.11 jq
 WORKDIR /app-root
 
 # PYTHONDONTWRITEBYTECODE 1 : disable the generation of .pyc

--- a/lightspeed-stack/Containerfile.lsc
+++ b/lightspeed-stack/Containerfile.lsc
@@ -23,7 +23,7 @@ RUN pip3.12 install uv
 # (avoid accidental inclusion of local directories or env files or credentials)
 COPY lightspeed-stack/pyproject.toml lightspeed-stack/uv.lock LICENSE.md README.md ./
 
-RUN uv sync --no-install-project --no-dev
+RUN uv sync --locked --no-install-project --no-dev
 # ======================================================
 
 # ======================================================

--- a/lightspeed-stack/entrypoint.sh
+++ b/lightspeed-stack/entrypoint.sh
@@ -23,4 +23,4 @@ else
   fi
 fi
 
-python3.11 src/lightspeed_stack.py --config /.llama/data/lightspeed-stack.yaml
+python3.12 src/lightspeed_stack.py --config /.llama/data/lightspeed-stack.yaml

--- a/lightspeed-stack/pyproject.toml
+++ b/lightspeed-stack/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "ansible-chatbot-stack"
 version = "0.1.0"
-description = "Ansible Lightspeed Intelligent Assistant (LSIA)"
+description = "Ansible Lightspeed Intelligent Assistant (ALIA)"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Further to https://github.com/ansible/ansible-chatbot-stack/pull/52 this PR installs `jq` to our Container Image.

This makes it easier to parse `ansible-chatbot-version-info.json`.

I also included a fix that was preventing our container running following our move to Python 3.12.

## Testing
```
export ANSIBLE_CHATBOT_VERSION=0.0.1
make build-lsc
docker run -it --entrypoint /bin/bash ansible-chatbot-stack:0.0.1
cd /.llama/distributions/ansible-chatbot-stack
cat ./ansible-chatbot-version-info.json | jq.version
```
This should return `"0.0.1"`.

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
