### PR TITLE
Install uv for GitHub Actions.

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           python-version: 3.11
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        
       - name: Environment Setup
         run: |
           make setup


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
The changes in #57 moved to using `uv` as the Python package manager.

`uv` is however not installed in `ubuntu-latest` by default.

This PR installs it.

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
