### PR TITLE
Pull 'providers.d' from GHA to ensure the same context is used.

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -12,17 +12,11 @@ jobs:
 
   build_push:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
+
     env:
       ANSIBLE_CHATBOT_VERSION: ${{ github.event.inputs.version }}
 
     steps:
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Login to Quay
         uses: docker/login-action@v3
@@ -43,10 +37,14 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-        
-      - name: Environment Setup
+
+      - name: Fetch providers.d information
         run: |
-          make setup
+          mkdir -p llama-stack/providers.d/inline/agents/
+          curl -o llama-stack/providers.d/inline/agents/lightspeed_inline_agent.yaml https://raw.githubusercontent.com/lightspeed-core/lightspeed-providers/refs/heads/main/resources/external_providers/inline/agents/lightspeed_inline_agent.yaml
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Ansible Chatbot Stack Build and Push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Seems like the `docker/build-push-action` is (possibly) looking for files in `github.workspace`.

This is possibly different to where our `makefile` pulls them.

Trying to fetch `providers.d` from a GHA step instead.....

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
