### PR TITLE
Include docker/build-push-action context.

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -52,6 +52,7 @@ jobs:
           file: Containerfile
           push: true
           tags: quay.io/ansible/ansible-chatbot-stack:latest,quay.io/ansible/ansible-chatbot-stack:${{ env.ANSIBLE_CHATBOT_VERSION }}
+          context: .
 
       - name: Create GitHub Repository Tag
         id: create_gh_repo_tag


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Based upon [this](https://stackoverflow.com/questions/72575700/running-docker-from-github-actions-cant-find-file-added-during-previous-step) I might need to include the Action's `context` parameter....

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
