### PR TITLE
AAP-48373: llama-stack: Tidy-up ansible-chatbot-stack once LSC supports required features.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,10 +34,9 @@ FROM quay.io/lightspeed-core/lightspeed-stack:dev-latest
 USER 0
 
 # Re-declaring arguments without a value, inherits the global default one.
+ARG APP_ROOT
 ARG ANSIBLE_CHATBOT_VERSION
-ARG APP_ROOT=/app-root
 RUN microdnf install -y --nodocs --setopt=keepcache=0 --setopt=tsflags=nodocs python3.11 jq
-WORKDIR /app-root
 
 # PYTHONDONTWRITEBYTECODE 1 : disable the generation of .pyc
 # PYTHONUNBUFFERED 1 : force the stdout and stderr streams to be unbuffered
@@ -49,7 +48,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONIOENCODING=UTF-8 \
     LANG=en_US.UTF-8
 
-COPY --from=builder --chown=1001:1001 /app-root /app-root
+COPY --from=builder /app-root /app-root
 
 # this directory is checked by ecosystem-cert-preflight-checks task in Konflux
 COPY --from=builder /app-root/LICENSE.md /licenses/
@@ -62,6 +61,7 @@ ENV LLAMA_STACK_CONFIG_DIR=/.llama/data
 # Data and configuration
 RUN mkdir -p /.llama/distributions/ansible-chatbot
 RUN mkdir -p /.llama/data/distributions/ansible-chatbot
+ADD lightspeed-stack.yaml /.llama/distributions/ansible-chatbot
 ADD ansible-chatbot-run.yaml /.llama/distributions/ansible-chatbot
 RUN echo -e "\
 {\n\

--- a/ansible-chatbot-run.yaml
+++ b/ansible-chatbot-run.yaml
@@ -79,14 +79,14 @@ models:
   provider_model_id: null
 - metadata:
     embedding_dimension: 768
-  model_id: ./embeddings_model
+  model_id: /.llama/data/distributions/ansible-chatbot/embeddings_model
   provider_id: inline_sentence-transformer
   model_type: embedding
 shields: []
 vector_dbs:
 - metadata: {}
   vector_db_id: "aap-product-docs-2_5"
-  embedding_model: ./embeddings_model
+  embedding_model: /.llama/data/distributions/ansible-chatbot/embeddings_model
   embedding_dimension: 768
   provider_id: "aap_faiss"
 datasets: []

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,8 +2,8 @@
 MOUNTPATH=/.llama/data
 
 echo "Checking preloaded embedding model..."
-if [[ -e ./embeddings_model ]]; then
-  echo "./embeddings_model already exists."
+if [[ -e /.llama/data/distributions/ansible-chatbot/embeddings_model ]]; then
+  echo "/.llama/data/distributions/ansible-chatbot/embeddings_model already exists."
 else
   if [[ ! -d ${MOUNTPATH} ]]; then
     echo "Volume mount path is not found."
@@ -13,14 +13,14 @@ else
       echo "Embedding model is not found on the volume mount path."
       exit 1
     else
-      ln -s ${MOUNTPATH}/embeddings_model ./embeddings_model
+      ln -s ${MOUNTPATH}/embeddings_model /.llama/data/distributions/ansible-chatbot/embeddings_model
       if [[ $? != 0 ]]; then
         echo "Failed to create symlink ./embeddings_model"
         exit 1
       fi
-      echo "Symlink ./embeddings_model has been created."
+      echo "Symlink /.llama/data/distributions/ansible-chatbot/embeddings_model has been created."
     fi
   fi
 fi
 
-python3.12 src/lightspeed_stack.py --config /.llama/data/lightspeed-stack.yaml
+python3.12 /app-root/src/lightspeed_stack.py --config /.llama/distributions/ansible-chatbot/lightspeed-stack.yaml


### PR DESCRIPTION
Jira Issue: https://issues.redhat.com/browse/AAP-48373

## Description
This PR fixes issues found deploying `ansible-chatbot-stack` on OpenShift.

## Testing
```
export ANSIBLE_CHATBOT_VERSION=0.0.1
export ANSIBLE_CHATBOT_INFERENCE_MODEL=...
export ANSIBLE_CHATBOT_VLLM_URL=...
export ANSIBLE_CHATBOT_VLLM_API_TOKEN=...

make setup
make build
make run
```

### Steps to test
As above.

### Scenarios tested
As above.

I also deployed a build of `ansible-chatbot-stack` from this PR to `stage2-west` and it started up OK.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
