### PR TITLE
Align provider_id with that used in road-core

### DIFF
--- a/ansible-chatbot-run.yaml
+++ b/ansible-chatbot-run.yaml
@@ -11,7 +11,7 @@ apis:
 - tool_runtime
 providers:
   inference:
-  - provider_id: rhosai_vllm_dev
+  - provider_id: my_rhoai_dev
     provider_type: remote::vllm
     config:
       url: ${env.VLLM_URL}
@@ -75,7 +75,7 @@ metadata_store: null
 models:
 - metadata: {}
   model_id: ${env.INFERENCE_MODEL}
-  provider_id: rhosai_vllm_dev
+  provider_id: my_rhoai_dev
   provider_model_id: null
 - metadata:
     embedding_dimension: 768


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Align the `inference` `provider_id` with that used by `ansible-ai-connect-service` and `ansible-chatbot-service`.

This better supports switching between either `ansible-chatbot-service` or `ansible-chatbot-stack`.

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
