### PR TITLE
Externalize system_prompt. ConfigMap VolumeMount overwrites existing content.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ run: check-env-run
 	  -v ./embeddings_model:/.llama/data/embeddings_model \
 	  -v ./vector_db/aap_faiss_store.db:$(CONTAINER_DB_PATH)/aap_faiss_store.db \
 	  -v ./lightspeed-stack.yaml:/.llama/data/lightspeed-stack.yaml \
-	  -v ./ansible-chatbot-system-prompt.txt:/.llama/distributions/ansible-chatbot/ansible-chatbot-system-prompt.txt \
+	  -v ./ansible-chatbot-system-prompt.txt:/.llama/distributions/ansible-chatbot/system-prompts/default.txt \
 	  --env VLLM_URL=$(ANSIBLE_CHATBOT_VLLM_URL) \
 	  --env VLLM_API_TOKEN=$(ANSIBLE_CHATBOT_VLLM_API_TOKEN) \
 	  --env INFERENCE_MODEL=$(ANSIBLE_CHATBOT_INFERENCE_MODEL) \

--- a/lightspeed-stack.yaml
+++ b/lightspeed-stack.yaml
@@ -13,4 +13,4 @@ user_data_collection:
   feedback_disabled: true
   transcripts_disabled: true
 customization:
-  system_prompt_path: /.llama/distributions/ansible-chatbot/ansible-chatbot-system-prompt.txt
+  system_prompt_path: /.llama/distributions/ansible-chatbot/system-prompts/default.txt


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Further to #65 deployment to OpenShift failed when using a `ConfigMap` `VolumeMount`.

This was found to be caused by `ConfigMap` `VolumeMount`'s overwriting all existing content.

This PR moves `system_prompt`'s to a new (empty) folder.

## Testing
```
export ANSIBLE_CHATBOT_VERSION=0.1.2
make build

export ANSIBLE_CHATBOT_INFERENCE_MODEL=...
export ANSIBLE_CHATBOT_VLLM_URL=...
export ANSIBLE_CHATBOT_VLLM_API_TOKEN=...
make run

make run-test
```

### Steps to test
As above.

### Scenarios tested
As above.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
