### PR TITLE
Specify metadata store explicitly in the run file

### DIFF
--- a/ansible-chatbot-run.yaml
+++ b/ansible-chatbot-run.yaml
@@ -71,7 +71,10 @@ providers:
   - provider_id: model-context-protocol
     provider_type: remote::model-context-protocol
     config: {}
-metadata_store: null
+metadata_store:
+  namespace: null
+  type: sqlite
+  db_path: ${env.PROVIDERS_DB_DIR:/.llama/data/distributions/ansible-chatbot}/registry.db
 models:
 - metadata: {}
   model_id: ${env.INFERENCE_MODEL}


### PR DESCRIPTION
<!--- Put Jira story/task/bug number in the link below or remove the next line and uncomment one below it. -->
Jira Issue: n/a
<!-- This PR does not need a corresponding Jira item. -->

## Description
<!-- Describe the changes introduced in the PR below, including any relevant motivation, context, and technical/design decisions -->
Specify metadata_store explicitly in the run file. Without specifying it, llama-stack creates `DISTRIBS_BASE_DIR / image_name / "kvstore.db"` ([link](https://github.com/meta-llama/llama-stack/blob/cd8715d3279ee7df731fec3e2e375d3c04126488/llama_stack/distribution/store/registry.py#L199-L201)).  When ansible-chatbot-stack is running from source (#67), we want to have all DBs created under `./work`.

## Testing
<!-- Describe the testing process in a set of steps, including any relevant env vars, user configuration, etc. If testing is not applicable, remove the steps and add a statement explaining why testing isn't applicable. -->
### Steps to test
1. Pull down the PR
2. Set up a local environment to run ansible-chatbot-stack from source
3. Start ansible-chatbot-stack frm source and verify `registry.db` is created in `./work`.

### Scenarios tested
<!-- Describe the scenarios you've already manually verified, if applicable. -->
Local manual testing only.

## Production deployment
<!-- Check the appropriate box. Document any pre-reqs, co-reqs, secrets, configmaps, etc that need to be considered or prepared ahead of a deployment to production. Include links to any related PRs, e.g. in ansible-wisdom-ops. -->
- [X] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
