### PR TITLE
Bump lightspeed-stack to 0.1.3

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ ARG ANSIBLE_CHATBOT_VERSION=latest
 # ======================================================
 # Transient image to construct Python venv
 # ------------------------------------------------------
-FROM quay.io/lightspeed-core/lightspeed-stack:0.1.2 AS builder
+FROM quay.io/lightspeed-core/lightspeed-stack:0.1.3 AS builder
 
 ARG APP_ROOT=/app-root
 WORKDIR /app-root


### PR DESCRIPTION
This PR does not need a corresponding Jira item.

## Description
Bump `lightspeed-stack` to `0.1.3` that includes the `/readiness` endpoint fix.

## Testing
N/A

### Steps to test
N/A

### Scenarios tested
N/A

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:
