### PR TITLE
dependencies: allow 1.11 or greater

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "aiosqlite~=0.21.0",
-    "faiss-cpu~=1.11.0",
+    "faiss-cpu~=1.11",
     "fire~=0.7.0",
     "lightspeed-stack-providers==0.1.14",
     "mcp~=1.9.4",


### PR DESCRIPTION
This to get access to this recent change released with `1.12`:

https://github.com/kyamagu/faiss-wheels/commit/193b4dc189f1e3a0792537c241bf5d4a1bbcd51d
