### PR TITLE
Bump starlette 0.52.1 → 1.2.0 for CVE-2026-48710

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "pyjwt[crypto]==2.12.1", # Transient dep pinned to handle CVE
     "python-multipart==0.0.22", # Transient dep pinned to handle CVE
     "sentence-transformers==5.3.0",
-    "starlette==0.52.1",
+    "starlette==1.2.0",  # Transient dep pinned to handle CVE
     "urllib3==2.7.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -193,7 +193,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = "==0.0.22" },
     { name = "sentence-transformers", specifier = "==5.3.0" },
-    { name = "starlette", specifier = "==0.52.1" },
+    { name = "starlette", specifier = "==1.2.0" },
     { name = "urllib3", specifier = "==2.7.0" },
 ]
 
@@ -2951,15 +2951,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/bf/616a066c2760f6c2b1ae3437cc28149734d069fbb46511712beae118a68c/starlette-1.2.0.tar.gz", hash = "sha256:3c5a6b23fff42492914e93890bb80cbfea72dbf37de268eec06185d62a4ca553", size = 2668923, upload-time = "2026-05-28T11:42:50.568Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/85/492183764d5d01d4514be3730fdb8e228a80605783099551c51627578b5d/starlette-1.2.0-py3-none-any.whl", hash = "sha256:36e0c76ac59157e75dc4b3bdeafba97fb04eaf1878045f15dbef666a6f092ed7", size = 73213, upload-time = "2026-05-28T11:42:48.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps starlette from 0.52.1 to 1.2.0 to address [CVE-2026-48710](https://www.cve.org/CVERecord?id=CVE-2026-48710) ("BadHost" authentication bypass)
- Starlette is a transitive dependency pulled in via `lightspeed-stack-providers` → `llama-stack` → `FastAPI` → `starlette`. Neither this repo nor its code directly imports or uses starlette or `request.url.path`
- FastAPI 0.135.x requires `starlette>=0.46.0`, so 1.2.0 is fully compatible
- Related Jira: AAP-76898
- See also: https://github.com/fastapi/fastapi/discussions/15593

## Test plan
- [ ] TBD — spin up and validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)