### PR TITLE
fix: pin transformers>=5.5.0 to address CVE-2026-5241

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyjwt[crypto]==2.12.1", # Transient dep pinned to handle CVE
     "python-multipart==0.0.22", # Transient dep pinned to handle CVE
     "sentence-transformers==5.3.0",
+    "transformers>=5.5.0", # Transient dep pinned to handle CVE
     "starlette==1.2.0",  # Transient dep pinned to handle CVE
     "urllib3==2.7.0",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -162,6 +162,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "sentence-transformers" },
     { name = "starlette" },
+    { name = "transformers" },
     { name = "urllib3" },
 ]
 
@@ -194,6 +195,7 @@ requires-dist = [
     { name = "python-multipart", specifier = "==0.0.22" },
     { name = "sentence-transformers", specifier = "==5.3.0" },
     { name = "starlette", specifier = "==1.2.0" },
+    { name = "transformers", specifier = ">=5.5.0" },
     { name = "urllib3", specifier = "==2.7.0" },
 ]
 


### PR DESCRIPTION
## Summary

- Adds `transformers>=5.5.0` as a transient dependency pin in `pyproject.toml` to address CVE-2026-5241
- CVE-2026-5241 is an arbitrary code execution vulnerability in huggingface/transformers via the LightGlue model loading path (introduced in 5.2.0, fixed in 5.5.0)
- `transformers` is pulled in transitively by `sentence-transformers==5.3.0`, which allows any version `>=4.41.0,<6.0.0` — without an explicit floor, the resolver may pick a vulnerable version

## Related

- CVE: https://www.cve.org/CVERecord?id=CVE-2026-5241
- Jira: [AAP-77784](https://redhat.atlassian.net/browse/AAP-77784)

## Test plan

- [ ] Verify `uv lock` resolves `transformers>=5.5.0`
- [ ] Verify downstream container `requirements.txt` regeneration picks up the fix

Made with [Cursor](https://cursor.com)