### PR TITLE
AAP-78027: Bump PyJWT to 2.13.0 (CVE-2026-48526)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pillow==12.2.0", # Transient dep pinned to handle CVE
     "python-dotenv>=1.2.2", # Transient dep pinned to handle CVE
     "pyasn1==0.6.3",
-    "pyjwt[crypto]==2.12.1", # Transient dep pinned to handle CVE
+    "pyjwt[crypto]==2.13.0", # Transient dep pinned to handle CVE
     "python-multipart==0.0.22", # Transient dep pinned to handle CVE
     "sentence-transformers==5.3.0",
     "transformers>=5.5.0", # Transient dep pinned to handle CVE

--- a/uv.lock
+++ b/uv.lock
@@ -190,7 +190,7 @@ requires-dist = [
     { name = "mcp", specifier = "==1.26.0" },
     { name = "pillow", specifier = "==12.2.0" },
     { name = "pyasn1", specifier = "==0.6.3" },
-    { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.1" },
+    { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = "==0.0.22" },
     { name = "sentence-transformers", specifier = "==5.3.0" },
@@ -2337,11 +2337,11 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Security Fix

Bumps `PyJWT` from 2.12.1 to 2.13.0 to address **CVE-2026-48526** — authentication bypass due to forged JSON Web Tokens.

**Flaw:** Prior to 2.13.0, when the verifier is decoding JWTs while supporting both asymmetric and HMAC algorithms, the library does not validate use of JSON Web Keys in HMAC algorithm, allowing an attacker to use the issuer public key as the secret key for HMAC.

**Risk level:** Low — PyJWT is a transitive dependency with no direct imports in this codebase.

**Jira:** [AAP-78027](https://redhat.atlassian.net/browse/AAP-78027)

- [x] This is a security fix
- [ ] Backport to stable branches (downstream PyJWT is already at 2.13.0 on stable-2.7; stable-2.6 tracked separately)

## Changes

- `pyproject.toml`: `pyjwt[crypto]==2.12.1` → `pyjwt[crypto]==2.13.0`
- `uv.lock`: regenerated via `uv lock`

Made with [Cursor](https://cursor.com)