### PR TITLE
Add script to generate system prompt files from upstream operator template

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,17 @@ Using the [`gemini` remote inference provider](https://llama-stack.readthedocs.i
 ```
 
 
+## Appendix - Generating system prompt files
+
+The system prompt files (`ansible-chatbot-system-prompt.txt` and `ansible-chatbot-system-prompt-granite-compat.txt`)
+are generated from the upstream [operator template](https://github.com/ansible/ansible-ai-connect-operator/blob/main/roles/chatbot/templates/chatbot.configmap_system_prompt.yaml.j2).
+
+To regenerate them after the upstream template changes:
+
+```shell
+    python3 scripts/generate_system_prompts.py
+```
+
 ## Appendix - Host clean-up
 
 If you have the need for re-building images, apply the following clean-ups right before:

--- a/ansible-chatbot-system-prompt-granite-compat.txt
+++ b/ansible-chatbot-system-prompt-granite-compat.txt
@@ -35,11 +35,11 @@ VALIDATION_STEP_2: Input Classification & Scope Check
 - **CRITICAL SCOPE RULE**: You *ONLY* answer questions related to Ansible and Ansible Automation Platform (AAP) topics.
 
 - **ALWAYS IN SCOPE (Technical Terms)**:
-    - **AAP-Specific**: Jobs, Job Templates, Templates (in automation context), Workflows, Inventories, Credentials, Organizations, Teams, Projects, Execution Environments, RBAC, Controller, Hub, EDA, Surveys, Schedules, Notifications, Activity Stream, Instance Groups, Mesh.
+    - **AAP-Specific**: Jobs, Job Templates, Templates (in automation context), Workflows, Inventories, Credentials, Organizations, Teams, Projects, Execution Environments, RBAC, Controller, Hub, EDA, Surveys, Schedules, Notifications, Activity Stream, Instance Groups, Mesh, Playbook Review, Playbook Approval, Deployment Process (in automation context), Naming Conventions (in automation context), Escalation Process (in automation context).
     - **Ansible-Specific**: Playbooks, roles, tasks, handlers, modules, collections, Galaxy, variables, facts, vault, Jinja2 templates (in automation context).
     - **General**: Ansible Lightspeed, Red Hat automation, version questions, configuration, troubleshooting, API endpoints, authentication.
 
-- **AMBIGUITY RULE**: If a term COULD be AAP-related (e.g., "jobs," "templates," "credentials"), **ALWAYS assume it IS in scope** unless the user explicitly indicates a non-AAP context (e.g., "What are employment jobs?").
+- **AMBIGUITY RULE**: If a term COULD be AAP-related (e.g., "jobs," "templates," "credentials"), **ALWAYS assume it IS in scope** unless the user explicitly indicates a non-AAP context (e.g., "What are employment jobs?"). Organizational or procedural questions that contain ANY Ansible/AAP term (playbook, role, job, inventory, collection, automation, execution environment, ansible-navigator) MUST be treated as in scope — this includes questions about approval processes, naming standards, debugging procedures, escalation paths, and operational policies for Ansible automation.
 
 - **REJECT (Clearly Unrelated Topics)**:
     - Other automation tools (unless comparing to Ansible)
@@ -93,8 +93,8 @@ For validated Ansible/AAP queries:
 - Maintain professional technical tone
 - Use appropriate tool calls when knowledge retrieval is required
 - **LINK SOURCE PRIORITY FILTER (CRITICAL)**: When extracting links from the tool output, you **MUST** prioritize and retain only links that originate from the official Red Hat Ansible Automation Platform (AAP) documentation domains.
-    * **PRIORITIZE/RETAIN**: Links containing **docs.redhat.com/en/documentation/red_hat_ansible_automation_platform** or **docs.redhat.com/aap/** (official Red Hat AAP documentation).
-    * **DISCARD/DE-PRIORITIZE**: Links from generic sources like `github.com`, `ansible.com/blog/`, `forum.ansible.com`, or general community pages (`docs.ansible.com/projects/ansible/latest/...`). If no official Red Hat link exists, you may use the next best source, but **Red Hat documentation is the primary source of truth.**
+    * **PRIORITIZE/RETAIN**: Links containing **docs.redhat.com/en/documentation/red_hat_ansible_automation_platform** or **docs.redhat.com/aap/** (official Red Hat AAP documentation). Links retrieved from the organization's knowledge base MUST also be retained — these are the canonical sources for org-specific policies, custom collections, and internal standards, regardless of which domain or hosting platform they originate from.
+    * **DISCARD/DE-PRIORITIZE**: Links from generic community sources like `ansible.com/blog/`, `forum.ansible.com`, or general community pages unrelated to the query. If no official Red Hat or organization-sourced link exists, use the next best source, but **Red Hat documentation is the primary source of truth.**
 </RESPONSE_PARAMETERS>
 
 <METACOGNITIVE_ANCHORS>

--- a/ansible-chatbot-system-prompt.txt
+++ b/ansible-chatbot-system-prompt.txt
@@ -35,11 +35,11 @@ VALIDATION_STEP_2: Input Classification & Scope Check
 - **CRITICAL SCOPE RULE**: You *ONLY* answer questions related to Ansible and Ansible Automation Platform (AAP) topics.
 
 - **ALWAYS IN SCOPE (Technical Terms)**:
-    - **AAP-Specific**: Jobs, Job Templates, Templates (in automation context), Workflows, Inventories, Credentials, Organizations, Teams, Projects, Execution Environments, RBAC, Controller, Hub, EDA, Surveys, Schedules, Notifications, Activity Stream, Instance Groups, Mesh.
+    - **AAP-Specific**: Jobs, Job Templates, Templates (in automation context), Workflows, Inventories, Credentials, Organizations, Teams, Projects, Execution Environments, RBAC, Controller, Hub, EDA, Surveys, Schedules, Notifications, Activity Stream, Instance Groups, Mesh, Playbook Review, Playbook Approval, Deployment Process (in automation context), Naming Conventions (in automation context), Escalation Process (in automation context).
     - **Ansible-Specific**: Playbooks, roles, tasks, handlers, modules, collections, Galaxy, variables, facts, vault, Jinja2 templates (in automation context).
     - **General**: Ansible Lightspeed, Red Hat automation, version questions, configuration, troubleshooting, API endpoints, authentication.
 
-- **AMBIGUITY RULE**: If a term COULD be AAP-related (e.g., "jobs," "templates," "credentials"), **ALWAYS assume it IS in scope** unless the user explicitly indicates a non-AAP context (e.g., "What are employment jobs?").
+- **AMBIGUITY RULE**: If a term COULD be AAP-related (e.g., "jobs," "templates," "credentials"), **ALWAYS assume it IS in scope** unless the user explicitly indicates a non-AAP context (e.g., "What are employment jobs?"). Organizational or procedural questions that contain ANY Ansible/AAP term (playbook, role, job, inventory, collection, automation, execution environment, ansible-navigator) MUST be treated as in scope — this includes questions about approval processes, naming standards, debugging procedures, escalation paths, and operational policies for Ansible automation.
 
 - **REJECT (Clearly Unrelated Topics)**:
     - Other automation tools (unless comparing to Ansible)
@@ -89,8 +89,8 @@ For validated Ansible/AAP queries:
 - Maintain professional technical tone
 - Use appropriate tool calls when knowledge retrieval is required
 - **LINK SOURCE PRIORITY FILTER (CRITICAL)**: When extracting links from the tool output, you **MUST** prioritize and retain only links that originate from the official Red Hat Ansible Automation Platform (AAP) documentation domains.
-    * **PRIORITIZE/RETAIN**: Links containing **docs.redhat.com/en/documentation/red_hat_ansible_automation_platform** or **docs.redhat.com/aap/** (official Red Hat AAP documentation).
-    * **DISCARD/DE-PRIORITIZE**: Links from generic sources like `github.com`, `ansible.com/blog/`, `forum.ansible.com`, or general community pages (`docs.ansible.com/projects/ansible/latest/...`). If no official Red Hat link exists, you may use the next best source, but **Red Hat documentation is the primary source of truth.**
+    * **PRIORITIZE/RETAIN**: Links containing **docs.redhat.com/en/documentation/red_hat_ansible_automation_platform** or **docs.redhat.com/aap/** (official Red Hat AAP documentation). Links retrieved from the organization's knowledge base MUST also be retained — these are the canonical sources for org-specific policies, custom collections, and internal standards, regardless of which domain or hosting platform they originate from.
+    * **DISCARD/DE-PRIORITIZE**: Links from generic community sources like `ansible.com/blog/`, `forum.ansible.com`, or general community pages unrelated to the query. If no official Red Hat or organization-sourced link exists, use the next best source, but **Red Hat documentation is the primary source of truth.**
 </RESPONSE_PARAMETERS>
 
 <METACOGNITIVE_ANCHORS>

--- a/scripts/generate_system_prompts.py
+++ b/scripts/generate_system_prompts.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Generate system prompt files from the upstream operator Jinja2 template.
+
+Downloads the chatbot system prompt template from ansible-ai-connect-operator
+and renders it with the appropriate variables to produce:
+  - ansible-chatbot-system-prompt.txt (openai provider)
+  - ansible-chatbot-system-prompt-granite-compat.txt (rhoai_vllm + granite model)
+"""
+
+import os
+import sys
+import urllib.request
+
+import jinja2
+import yaml
+
+TEMPLATE_URL = (
+    "https://raw.githubusercontent.com/ansible/ansible-ai-connect-operator/"
+    "refs/heads/main/roles/chatbot/templates/"
+    "chatbot.configmap_system_prompt.yaml.j2"
+)
+
+PRODUCT_NAME = "Automation Intelligent Assistant"
+
+OUTPUT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+VARIANTS = [
+    {
+        "output_file": "ansible-chatbot-system-prompt.txt",
+        "variables": {
+            "chatbot_llm_provider_type": "openai",
+            "chatbot_model": "gpt-4o-mini",
+        },
+    },
+    {
+        "output_file": "ansible-chatbot-system-prompt-granite-compat.txt",
+        "variables": {
+            "chatbot_llm_provider_type": "rhoai_vllm",
+            "chatbot_model": "granite-3.3-8b-instruct",
+        },
+    },
+]
+
+
+def download_template(url):
+    with urllib.request.urlopen(url) as resp:
+        return resp.read().decode("utf-8")
+
+
+def render_template(template_source, variables):
+    env = jinja2.Environment(
+        undefined=jinja2.Undefined,
+        trim_blocks=True,
+        lstrip_blocks=True,
+    )
+    env.globals["lookup"] = lambda *args, **kwargs: "placeholder: true"
+    template = env.from_string(template_source)
+    rendered = template.render(
+        chatbot_product_name=PRODUCT_NAME,
+        ansible_operator_meta={"name": "placeholder", "namespace": "placeholder"},
+        deployment_type="placeholder",
+        **variables,
+    )
+    return rendered
+
+
+def extract_system_prompt(rendered_yaml):
+    doc = yaml.safe_load(rendered_yaml)
+    return doc["data"]["DEFAULT_SYSTEM_PROMPT"]
+
+
+def main():
+    print(f"Downloading template from:\n  {TEMPLATE_URL}")
+    template_source = download_template(TEMPLATE_URL)
+    print("Template downloaded successfully.\n")
+
+    for variant in VARIANTS:
+        output_path = os.path.join(OUTPUT_DIR, variant["output_file"])
+        print(f"Generating {variant['output_file']}...")
+        print(f"  provider_type={variant['variables']['chatbot_llm_provider_type']}")
+        if variant["variables"].get("chatbot_model"):
+            print(f"  model={variant['variables']['chatbot_model']}")
+
+        rendered = render_template(template_source, variant["variables"])
+        prompt = extract_system_prompt(rendered)
+
+        with open(output_path, "w") as f:
+            f.write(prompt + "\n")
+
+        print(f"  Written to: {output_path}\n")
+
+    print("Done.")
+
+
+if __name__ == "__main__":
+    main()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -38,5 +38,8 @@ sonar.exclusions = \
   .coverage,\
   coverage.xml
 
+# Exclude utility scripts from coverage analysis
+sonar.coverage.exclusions = scripts/**
+
 # Enable quality gate
 sonar.qualitygate.wait=true


### PR DESCRIPTION
## Summary
- Add `scripts/generate_system_prompts.py` that downloads the Jinja2 template from `ansible-ai-connect-operator` and renders it to produce `ansible-chatbot-system-prompt.txt` (openai) and `ansible-chatbot-system-prompt-granite-compat.txt` (rhoai_vllm + granite)
- Regenerate both system prompt files to align with the latest upstream template
- Add an appendix section to README.md documenting the script

## Test plan
- [X] Run `python3 scripts/generate_system_prompts.py` and verify both output files are generated
- [X] Diff generated files against previous versions to confirm expected upstream changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)