### PR TITLE
fix: wait for MCP sidecar readiness before starting lightspeed-stack (AAP-80203)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,4 +109,74 @@ else
     echo "BYOK provider vector DB ID file not found: ${BYOK_PROVIDER_VECTOR_DB_ID_FILE_PATH}"
 fi
 
+# Wait for MCP sidecar endpoints to be ready before starting lightspeed-stack.
+# On OCP, all containers in a pod start simultaneously. The MCP sidecars may not
+# be listening yet when lightspeed_stack.py tries to register MCP tool groups,
+# causing a startup crash. This block polls each MCP server port until it accepts
+# TCP connections, then proceeds. If sidecars don't come up in time, the chatbot
+# starts anyway in degraded mode (without MCP tools).
+
+LIGHTSPEED_STACK_CONFIG="/.llama/distributions/ansible-chatbot/config/lightspeed-stack.yaml"
+MCP_WAIT_MAX_ATTEMPTS="${MCP_WAIT_MAX_ATTEMPTS:-30}"
+MCP_WAIT_INTERVAL="${MCP_WAIT_INTERVAL:-2}"
+
+wait_for_port() {
+    local host="$1"
+    local port="$2"
+    local label="${host}:${port}"
+    local attempt=1
+
+    echo "Waiting for MCP endpoint ${label} ..."
+    while [[ $attempt -le $MCP_WAIT_MAX_ATTEMPTS ]]; do
+        if python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.settimeout(2)
+try:
+    s.connect(('${host}', ${port}))
+    s.close()
+    sys.exit(0)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null; then
+            echo "MCP endpoint ${label} is ready (attempt ${attempt}/${MCP_WAIT_MAX_ATTEMPTS})"
+            return 0
+        fi
+        echo "MCP endpoint ${label} not ready (attempt ${attempt}/${MCP_WAIT_MAX_ATTEMPTS}), retrying in ${MCP_WAIT_INTERVAL}s..."
+        sleep "${MCP_WAIT_INTERVAL}"
+        attempt=$((attempt + 1))
+    done
+    echo "WARNING: MCP endpoint ${label} not ready after ${MCP_WAIT_MAX_ATTEMPTS} attempts ($(( MCP_WAIT_MAX_ATTEMPTS * MCP_WAIT_INTERVAL ))s). Starting in degraded mode."
+    return 1
+}
+
+if [[ "${MCP_WAIT_DISABLED:-false}" == "true" ]]; then
+    echo "MCP readiness check disabled (MCP_WAIT_DISABLED=true), skipping."
+elif [[ ! -f "${LIGHTSPEED_STACK_CONFIG}" ]]; then
+    echo "Config file not found at ${LIGHTSPEED_STACK_CONFIG}, skipping MCP readiness check."
+else
+    MCP_ENDPOINTS=$(grep -E '^\s+url:\s' "${LIGHTSPEED_STACK_CONFIG}" 2>/dev/null \
+        | grep -oE 'https?://[^"'"'"' ]+' \
+        | sed -E 's|https?://||; s|/.*||')
+
+    if [[ -n "${MCP_ENDPOINTS}" ]]; then
+        echo "MCP server endpoints detected, waiting for sidecar readiness..."
+        MCP_ALL_READY=true
+        for endpoint in ${MCP_ENDPOINTS}; do
+            host="${endpoint%%:*}"
+            port="${endpoint##*:}"
+            if ! wait_for_port "${host}" "${port}"; then
+                MCP_ALL_READY=false
+            fi
+        done
+        if [[ "${MCP_ALL_READY}" == "true" ]]; then
+            echo "All MCP endpoints are ready."
+        else
+            echo "WARNING: Not all MCP endpoints are ready. Chatbot will start without full MCP support."
+        fi
+    else
+        echo "No MCP server endpoints found in config, skipping readiness check."
+    fi
+fi
+
 ${PYTHON_CMD} /app-root/src/lightspeed_stack.py --config /.llama/distributions/ansible-chatbot/config/lightspeed-stack.yaml


### PR DESCRIPTION
## Summary

- Fixes the MCP tool registration race condition on OCP deployments (AAP-80203)
- Adds a TCP port polling loop in `entrypoint.sh` that waits for each MCP sidecar endpoint to accept connections before launching `lightspeed_stack.py`
- If sidecars don't come up within the configurable timeout (default 60s), the chatbot starts in degraded mode (without MCP tools) rather than crashing

## Root Cause

On OCP, all containers in a pod start simultaneously. The chatbot would attempt to register MCP tool groups before the sidecar containers (`ansible-mcp-controller`, `ansible-mcp-lightspeed`) were listening, causing MCP registration to silently fail. The chatbot then ran its entire lifecycle with only RAG tools, causing the `Chatbot > should have MCP conversation return a meaningful response` Playwright test to fail ~62% of the time on OCP (`tier1-ocp-a.fresh-install.ui-playwright`).

On containerized deployments this doesn't happen because MCP URLs are templated into the config at install time before any containers start.

## How it works

The fix adds a block before the final `lightspeed_stack.py` launch in `entrypoint.sh`:

1. Reads `lightspeed-stack.yaml` and extracts MCP server `host:port` pairs
2. For each endpoint, polls the TCP port using Python's `socket` module (no `curl` needed)
3. Retries up to `MCP_WAIT_MAX_ATTEMPTS` (default 30) times with `MCP_WAIT_INTERVAL` (default 2s) between attempts
4. If all endpoints respond, proceeds normally
5. If any endpoint times out, logs a WARNING and starts in degraded mode
6. Skips the check entirely when no MCP servers are configured (RAG-only mode)

## Configuration

| Env var | Default | Description |
|---------|---------|-------------|
| `MCP_WAIT_MAX_ATTEMPTS` | `30` | Max retry attempts per endpoint |
| `MCP_WAIT_INTERVAL` | `2` | Seconds between retries |
| `MCP_WAIT_DISABLED` | `false` | Set to `true` to skip the check entirely |

## Test plan

- [x] Verified on aap-dev Kind cluster with MCP sidecars -- wait logic polled `localhost:8004` for 20 attempts (~38s) until the sidecar was ready, then started successfully with 0 race-condition restarts
- [x] Verified RAG-only mode (no MCP servers in config) -- logs "No MCP server endpoints found in config, skipping readiness check" and starts normally
- [x] Existing CI integration tests pass (no MCP servers configured in test config)
- [ ] Request `tier1-ocp-a.fresh-install.ui-playwright` pipeline run with this fix to validate Playwright MCP test pass rate improves from ~38% to ~100%


Made with [Cursor](https://cursor.com)