### PR TITLE
Bump lightspeed-stack base image from 0.4.2 to 0.4.3.1

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,7 +6,7 @@ ARG GIT_COMMIT=git-commit-not-defined
 # ======================================================
 # Transient image to construct Python venv
 # ------------------------------------------------------
-FROM quay.io/lightspeed-core/lightspeed-stack:0.4.2 AS builder
+FROM quay.io/lightspeed-core/lightspeed-stack:0.4.3.1 AS builder
 
 ARG APP_ROOT=/app-root
 WORKDIR /app-root


### PR DESCRIPTION
## Summary
- Bumps the `lightspeed-stack` builder base image in the Containerfile from `0.4.2` to `0.4.3.1`
- Aligns with the version referenced by `ansible-lightspeed-chatbot-container` (`.gitmodules` branch `0.4.3.1`)
- Brings in Authlib 1.7.x which adds `joserfc>=1.6.0` as a transitive dependency, resolving missing authentication libraries at runtime

## Context
The production container (`lightspeed-chatbot-rhel9`) already uses lightspeed-stack 0.4.3.1 and ships `Authlib==1.7.2` + `joserfc==1.6.5`. The standalone `ansible-chatbot-stack` Containerfile was still pinned to 0.4.2 (which shipped `Authlib==1.6.9` without `joserfc`), causing a version mismatch between local and production builds.

## Test plan
- [x] Build the container image locally with `podman build -f Containerfile -t ansible-chatbot-stack:test .`
- [x] Verify `joserfc` is available: `podman run --rm ansible-chatbot-stack:test python3.12 -c "import joserfc; print(joserfc.__version__)"`
- [x] Verify `authlib` version is 1.7.x: `podman run --rm ansible-chatbot-stack:test python3.12 -c "import authlib; print(authlib.__version__)"`
- [x] Run existing tests against the updated image


Made with [Cursor](https://cursor.com)