### PR TITLE
Cap cryptography dependency below 51.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "aiohttp==3.14.3", # Transient dep pinned to handle CVE (CVE-2026-34993)
-    "cryptography==50.0.0", # Transient dep pinned to handle CVE
+    "cryptography>=50.0.0,<51", # Transient dep pinned to handle CVE
     "dumb-init>=1.2.5.post1",
     "faiss-cpu==1.12",
     "lightspeed-stack-providers==0.4.3",

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = "==3.14.3" },
-    { name = "cryptography", specifier = "==50.0.0" },
+    { name = "cryptography", specifier = ">=50.0.0,<51" },
     { name = "dumb-init", specifier = ">=1.2.5.post1" },
     { name = "faiss-cpu", specifier = "==1.12" },
     { name = "joserfc", specifier = ">=1.6.7" },


### PR DESCRIPTION
## Summary
- Change `cryptography` from `==50.0.0` to `>=50.0.0,<51` so we stay on the 50.x line
- Refresh `uv.lock` (still resolves to `50.0.0`)
- Keeps versioning style consistent with the `mcp` cap (`>=1.29.0,<2`) from #303

## Test plan
- [x] Confirm `uv.lock` still resolves `cryptography` to `50.0.0`
- [x] CI passes

Made with [Cursor](https://cursor.com)