### PR TITLE
bump sentence-transformers 5.3.0 → 5.7.0 (CVE-2026-68770)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "pyasn1>=0.6.4", # Bumped for CVE-2026-59886
     "pyjwt[crypto]==2.13.0", # Transient dep pinned to handle CVE
     "python-multipart==0.0.32", # CVE-2026-42561
-    "sentence-transformers==5.3.0",
+    "sentence-transformers==5.7.0", # Bumped for CVE-2026-68770
     "transformers>=5.5.0", # Transient dep pinned to handle CVE
     "starlette>=1.3.1",  # Bumped for CVE-2026-54283
     "joserfc>=1.6.7", # Transient dep from authlib, pinned for CVE-2026-48990

--- a/uv.lock
+++ b/uv.lock
@@ -209,7 +209,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = "==0.0.32" },
-    { name = "sentence-transformers", specifier = "==5.3.0" },
+    { name = "sentence-transformers", specifier = "==5.7.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "transformers", specifier = ">=5.5.0" },
     { name = "urllib3", specifier = "==2.7.0" },
@@ -3284,21 +3284,22 @@ wheels = [
 
 [[package]]
 name = "sentence-transformers"
-version = "5.3.0"
+version = "5.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "tokenizers" },
     { name = "torch" },
     { name = "tqdm" },
     { name = "transformers" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/26/448453925b6ce0c29d8b54327caa71ee4835511aef02070467402273079c/sentence_transformers-5.3.0.tar.gz", hash = "sha256:414a0a881f53a4df0e6cbace75f823bfcb6b94d674c42a384b498959b7c065e2", size = 403330, upload-time = "2026-03-12T14:53:40.778Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/59/867381b1414a975da6c9953f48a07c05cb0629305e2d37c9bcc9764367b2/sentence_transformers-5.7.0.tar.gz", hash = "sha256:fd8c8fc35e6323631dff9f3760969ebf7980dc3cfda0ab1354bc6a774cc0e5d8", size = 466382, upload-time = "2026-08-06T12:12:33.371Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/9c/2fa7224058cad8df68d84bafee21716f30892cecc7ad1ad73bde61d23754/sentence_transformers-5.3.0-py3-none-any.whl", hash = "sha256:dca6b98db790274a68185d27a65801b58b4caf653a4e556b5f62827509347c7d", size = 512390, upload-time = "2026-03-12T14:53:39.035Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c8/f63d99e354532f5b83e735dd1e001bda92495fbfde934f65d924abf2b071/sentence_transformers-5.7.0-py3-none-any.whl", hash = "sha256:b78141da3d8137e70d965866e2ca43190b9266f3d4d8752e250ded75e7136730", size = 611333, upload-time = "2026-08-06T12:12:31.881Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrades `sentence-transformers` from 5.3.0 to 5.7.0 to address [CVE-2026-68770](https://cve.threatint.com/CVE/CVE-2026-68770) (CVSS 9.8 Critical)
- Fixes: [AAP-86360](https://issues.redhat.com/browse/AAP-86360)

## CVE Details

**CVE-2026-68770** — a logic flaw in `import_module_class` (`sentence_transformers/util/misc.py`) bypasses the `trust_remote_code=False` guard when the model path exists on the local filesystem (`or os.path.exists(model_name_or_path)`). An attacker who can control a local model directory can place malicious `modeling_*.py` files that execute at import time.

The fix [landed in v5.6.0](https://github.com/UKPLab/sentence-transformers/pull/3807) (merged 2026-06-12) as a `FutureWarning`; v6.0 will remove the `os.path.exists` short-circuit entirely.

## Impact Assessment

**This repo is not practically exploitable** in its current configuration:

1. **Local path loading** — the embeddings model is loaded from `/.llama/data/embeddings_model` (a volume-mounted local path), so the first precondition _is_ met.
2. **No custom code in models** — the models used (`all-mpnet-base-v2`, `all-MiniLM-L6-v2`) reference only built-in `sentence_transformers.models.*` modules in their `modules.json`. No `modeling_*.py` custom code exists, so the vulnerable `import_module_class` code path is **never triggered**.
3. **No attacker-controlled model directory** — the model directory is volume-mounted from a pre-built container image, limiting the attack surface to supply-chain compromise.

However, the dependency version is still technically vulnerable, and a future model swap to one with custom code would silently become exploitable. Upgrading is a defense-in-depth measure.

## Breaking Change Risk: None

The API surface used by this project — `SentenceTransformer(path)`, `.encode()`, `.save()` (via llama-stack's `SentenceTransformerEmbeddingMixin` and `tests/setup_test_data.py`) — has been stable across all releases from v5.3 to v5.7.

Breaking changes in v5.4–v5.7 are all in unused areas:

| Breaking change | Version | Used here? |
|---|---|---|
| int8/uint8 quantization output | v5.7.0 | No |
| `AdaptiveLayerLoss` default weighting | v5.7.0 | No (inference only) |
| RoBERTa flash-attention position_ids | v5.6.1 | No (MPNet model, no flash attn) |
| Training loss fixes (GradCache, TSDAE, etc.) | v5.5–5.7 | No (inference only) |

## Test plan

- [ ] Verify `uv lock` resolves cleanly
- [ ] Run existing test suite (`make test`)
- [ ] Verify embeddings model loads and encodes correctly in containerized environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)