### PR TITLE
Add BYOK sanity tests alongside standard AAP RAG tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 
 
 
-.PHONY: help setup setup-test build build-custom run clean all deploy-k8s shell tag-and-push test update-lock
+.PHONY: help setup setup-test build build-custom run clean all deploy-k8s shell tag-and-push test update-lock test-sanity-byok
 
 .EXPORT_ALL_VARIABLES:
 
@@ -64,6 +64,7 @@ help:
 	@echo "  test-sanity-granite - Run Granite/vLLM sanity tests"
 	@echo "  test-sanity-openai  - Run real OpenAI sanity tests"
 	@echo "  test-sanity-azure   - Run Azure OpenAI sanity tests"
+	@echo "  test-sanity-byok    - Run BYOK sanity tests (requires inference provider env vars)"
 	@echo ""
 	@echo "Required Environment variables:"
 	@echo "  ANSIBLE_CHATBOT_VERSION                - Version tag for the image (default: $(ANSIBLE_CHATBOT_VERSION))"
@@ -303,3 +304,7 @@ test-sanity-openai:
 test-sanity-azure:
 	@echo "Running Azure OpenAI sanity tests (requires AZURE_OPENAI_BASE_URL, AZURE_OPENAI_API_KEY, AZURE_OPENAI_INFERENCE_MODEL)..."
 	uv run --frozen --group test pytest tests/sanity/ -v -m azure
+
+test-sanity-byok:
+	@echo "Running BYOK sanity tests (requires inference provider env vars + byok_vector_db/)..."
+	uv run --frozen --group test pytest tests/sanity/ -v -m byok

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,5 @@ markers = [
     "granite: tests using the in-house Granite LLM via vLLM (requires VLLM_URL, VLLM_API_TOKEN, INFERENCE_MODEL)",
     "openai_live: tests using the real OpenAI API (requires OPENAI_API_KEY, OPENAI_INFERENCE_MODEL)",
     "azure: tests using Azure OpenAI (requires AZURE_OPENAI_BASE_URL, AZURE_OPENAI_API_KEY, AZURE_OPENAI_INFERENCE_MODEL)",
+    "byok: tests using BYOK (Bring Your Own Knowledge) vector database alongside the standard AAP RAG",
 ]

--- a/tests/sanity/byok-lightspeed-stack.yaml
+++ b/tests/sanity/byok-lightspeed-stack.yaml
@@ -1,0 +1,24 @@
+name: Automation Intelligent Assistant (Sanity BYOK)
+service:
+  host: 0.0.0.0
+  port: 8322
+  auth_enabled: false
+  workers: 1
+  color_log: true
+  access_log: true
+llama_stack:
+  use_as_library_client: true
+  library_client_config_path: /.llama/distributions/llama-stack/config/ansible-chatbot-run.yaml
+user_data_collection:
+  feedback_enabled: false
+  transcripts_enabled: false
+customization:
+  system_prompt_path: /.llama/distributions/ansible-chatbot/system-prompts/default.txt
+byok_rag:
+  - rag_id: byok-docs
+    rag_type: inline::faiss
+    embedding_model: sentence-transformers/${env.EMBEDDINGS_MODEL:=/.llama/data/embeddings_model}
+    embedding_dimension: 768
+    vector_db_id: ${env.BYOK_PROVIDER_VECTOR_DB_ID:=}
+    db_path: /.llama/data/byok/distributions/ansible-chatbot/faiss_store.db
+    score_multiplier: 1.2

--- a/tests/sanity/conftest.py
+++ b/tests/sanity/conftest.py
@@ -29,6 +29,7 @@ _AZURE_REQUIRED = ["AZURE_OPENAI_BASE_URL", "AZURE_OPENAI_API_KEY", "AZURE_OPENA
 
 _SANITY_DIR = Path(__file__).parent
 _LIGHTSPEED_STACK_CONFIG = str(_SANITY_DIR / "lightspeed-stack.yaml")
+_BYOK_LIGHTSPEED_STACK_CONFIG = str(_SANITY_DIR / "byok-lightspeed-stack.yaml")
 
 
 def _check_required_vars(var_names):
@@ -38,12 +39,53 @@ def _check_required_vars(var_names):
         pytest.skip(f"Missing required environment variables: {', '.join(missing)}")
 
 
-def _start_sanity_server(run_config_path, lightspeed_config_path, env_overrides, provider, expected_model):  # noqa: cognitive-complexity
+def _build_provider_config(provider):
+    """Return (run_config_path, env_overrides, config_dict) for the given provider."""
+    if provider == "granite":
+        _check_required_vars(_GRANITE_REQUIRED)
+        env_overrides = {
+            "VLLM_URL": os.environ["VLLM_URL"],
+            "VLLM_API_TOKEN": os.environ["VLLM_API_TOKEN"],
+            "INFERENCE_MODEL": os.environ["INFERENCE_MODEL"],
+        }
+        if os.environ.get("VLLM_MAX_TOKENS"):
+            env_overrides["VLLM_MAX_TOKENS"] = os.environ["VLLM_MAX_TOKENS"]
+        if os.environ.get("VLLM_TLS_VERIFY"):
+            env_overrides["VLLM_TLS_VERIFY"] = os.environ["VLLM_TLS_VERIFY"]
+        run_config = str(_SANITY_DIR / "granite-chatbot-run.yaml")
+        config = {"model": f"granite/{os.environ['INFERENCE_MODEL']}", "provider": "granite"}
+
+    elif provider == "openai":
+        _check_required_vars(_OPENAI_REQUIRED)
+        env_overrides = {
+            "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
+            "OPENAI_INFERENCE_MODEL": os.environ["OPENAI_INFERENCE_MODEL"],
+        }
+        if os.environ.get("OPENAI_BASE_URL"):
+            env_overrides["OPENAI_BASE_URL"] = os.environ["OPENAI_BASE_URL"]
+        run_config = str(_SANITY_DIR / "openai-chatbot-run.yaml")
+        config = {"model": os.environ["OPENAI_INFERENCE_MODEL"], "provider": "openai"}
+
+    else:  # azure
+        _check_required_vars(_AZURE_REQUIRED)
+        env_overrides = {
+            "AZURE_OPENAI_BASE_URL": os.environ["AZURE_OPENAI_BASE_URL"],
+            "AZURE_OPENAI_API_KEY": os.environ["AZURE_OPENAI_API_KEY"],
+            "AZURE_OPENAI_INFERENCE_MODEL": os.environ["AZURE_OPENAI_INFERENCE_MODEL"],
+        }
+        run_config = str(_SANITY_DIR / "azure-chatbot-run.yaml")
+        config = {"model": os.environ["AZURE_OPENAI_INFERENCE_MODEL"], "provider": "openai_azure"}
+
+    return run_config, env_overrides, config
+
+
+def _start_sanity_server(run_config_path, lightspeed_config_path, env_overrides, provider, expected_model, byok_vector_db_path=None):  # noqa: cognitive-complexity
     """
     Start the chatbot container for a given provider config.
 
     Returns (process, container_runtime, container_name, env_file_path) for cleanup.
     If a server is already running on port 8322 with the expected model, skips container startup.
+    When byok_vector_db_path is set, the BYOK vector DB is mounted and configured.
     """
     # Check if server is already running
     server_running = False
@@ -71,6 +113,8 @@ def _start_sanity_server(run_config_path, lightspeed_config_path, env_overrides,
         pytest.fail("embeddings_model directory not found — run 'make setup-test' first")
     if not Path("./vector_db/aap_faiss_store.db").exists():
         pytest.fail("vector_db/aap_faiss_store.db not found — run 'make setup-test' first")
+    if byok_vector_db_path and not (_SANITY_DIR.parent.parent / byok_vector_db_path / "faiss_store.db").exists():
+        pytest.fail(f"{byok_vector_db_path}/faiss_store.db not found — run 'make setup-test' first")
     if not Path("./llama-stack/providers.d").exists():
         pytest.fail("llama-stack/providers.d directory not found — run 'make setup-test' first")
 
@@ -143,6 +187,19 @@ def _start_sanity_server(run_config_path, lightspeed_config_path, env_overrides,
         "--env", f"LOG_LEVEL={os.environ.get('LOG_LEVEL', 'INFO')}",
         "--env-file", env_file_path,
     ]
+
+    if byok_vector_db_path:
+        byok_vid_file = Path(byok_vector_db_path) / "provider_vector_db_id.ind"
+        byok_vector_db_id = os.environ.get("BYOK_PROVIDER_VECTOR_DB_ID", "")
+        if byok_vid_file.exists() and not byok_vector_db_id:
+            try:
+                byok_vector_db_id = byok_vid_file.read_text().strip()
+            except Exception:
+                pass
+        cmd += [
+            "-v", f"{_SANITY_DIR.parent.parent / byok_vector_db_path}:/.llama/data/byok/distributions/ansible-chatbot{selinux_flag}",
+            "--env", f"BYOK_PROVIDER_VECTOR_DB_ID={byok_vector_db_id}",
+        ]
 
     cmd.append(full_image)
 
@@ -280,44 +337,44 @@ def provider_setup(request):
     Skips automatically when required environment variables are not set.
     """
     provider = request.param
-
-    if provider == "granite":
-        _check_required_vars(_GRANITE_REQUIRED)
-        env_overrides = {
-            "VLLM_URL": os.environ["VLLM_URL"],
-            "VLLM_API_TOKEN": os.environ["VLLM_API_TOKEN"],
-            "INFERENCE_MODEL": os.environ["INFERENCE_MODEL"],
-        }
-        if os.environ.get("VLLM_MAX_TOKENS"):
-            env_overrides["VLLM_MAX_TOKENS"] = os.environ["VLLM_MAX_TOKENS"]
-        if os.environ.get("VLLM_TLS_VERIFY"):
-            env_overrides["VLLM_TLS_VERIFY"] = os.environ["VLLM_TLS_VERIFY"]
-        run_config = str(_SANITY_DIR / "granite-chatbot-run.yaml")
-        config = {"model": f"granite/{os.environ['INFERENCE_MODEL']}", "provider": "granite"}
-
-    elif provider == "openai":
-        _check_required_vars(_OPENAI_REQUIRED)
-        env_overrides = {
-            "OPENAI_API_KEY": os.environ["OPENAI_API_KEY"],
-            "OPENAI_INFERENCE_MODEL": os.environ["OPENAI_INFERENCE_MODEL"],
-        }
-        if os.environ.get("OPENAI_BASE_URL"):
-            env_overrides["OPENAI_BASE_URL"] = os.environ["OPENAI_BASE_URL"]
-        run_config = str(_SANITY_DIR / "openai-chatbot-run.yaml")
-        config = {"model": os.environ["OPENAI_INFERENCE_MODEL"], "provider": "openai"}
-
-    else:  # azure
-        _check_required_vars(_AZURE_REQUIRED)
-        env_overrides = {
-            "AZURE_OPENAI_BASE_URL": os.environ["AZURE_OPENAI_BASE_URL"],
-            "AZURE_OPENAI_API_KEY": os.environ["AZURE_OPENAI_API_KEY"],
-            "AZURE_OPENAI_INFERENCE_MODEL": os.environ["AZURE_OPENAI_INFERENCE_MODEL"],
-        }
-        run_config = str(_SANITY_DIR / "azure-chatbot-run.yaml")
-        config = {"model": os.environ["AZURE_OPENAI_INFERENCE_MODEL"], "provider": "openai_azure"}
-
+    run_config, env_overrides, config = _build_provider_config(provider)
     process, runtime, name, env_file_path = _start_sanity_server(
         run_config, _LIGHTSPEED_STACK_CONFIG, env_overrides, provider, config["model"]
+    )
+    try:
+        yield config
+    finally:
+        _stop_sanity_server(process, runtime, name)
+        if env_file_path:
+            try:
+                os.unlink(env_file_path)
+            except OSError:
+                pass
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("granite", marks=[pytest.mark.granite, pytest.mark.byok]),
+        pytest.param("openai", marks=[pytest.mark.openai_live, pytest.mark.byok]),
+        pytest.param("azure", marks=[pytest.mark.azure, pytest.mark.byok]),
+    ],
+    scope="module",
+)
+def byok_provider_setup(request):
+    """
+    Start the chatbot server with BYOK enabled for the given provider and yield its config.
+
+    Uses the same inference provider env vars as provider_setup, but mounts the BYOK
+    vector DB and uses byok-lightspeed-stack.yaml so both the standard AAP RAG and
+    the BYOK RAG are active simultaneously.
+    Skips automatically when required environment variables are not set.
+    """
+    provider = request.param
+    run_config, env_overrides, config = _build_provider_config(provider)
+    process, runtime, name, env_file_path = _start_sanity_server(
+        run_config, _BYOK_LIGHTSPEED_STACK_CONFIG, env_overrides,
+        provider=f"byok-{provider}", expected_model=config["model"],
+        byok_vector_db_path="byok_vector_db",
     )
     try:
         yield config

--- a/tests/sanity/test_byok.py
+++ b/tests/sanity/test_byok.py
@@ -1,0 +1,153 @@
+"""
+BYOK (Bring Your Own Knowledge) sanity tests for ansible-chatbot-stack.
+
+Tests run for each provider configured via the byok_provider_setup fixture:
+  - Granite (vLLM)  — requires VLLM_URL, VLLM_API_TOKEN, INFERENCE_MODEL
+  - OpenAI          — requires OPENAI_API_KEY, OPENAI_INFERENCE_MODEL
+  - Azure OpenAI    — requires AZURE_OPENAI_BASE_URL, AZURE_OPENAI_API_KEY,
+                               AZURE_OPENAI_INFERENCE_MODEL
+
+A provider is skipped automatically when its required variables are not set.
+The BYOK vector DB must exist at byok_vector_db/ (created by 'make setup-test').
+
+Examples:
+    make test-sanity-byok                 # all providers, BYOK mode
+    pytest tests/sanity/ -v -m byok       # same
+    pytest tests/sanity/ -v -m "byok and granite"  # Granite only
+"""
+
+import json
+
+import pytest
+import requests
+
+
+class TestBYOKSanity:
+    """Sanity tests for BYOK vector DB retrieval alongside the standard AAP RAG."""
+
+    def test_server_health(self, base_url, byok_provider_setup):
+        response = requests.get(f"{base_url}/v1/config", timeout=10)
+
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+        config_data = response.json()
+        assert config_data is not None
+        assert len(config_data) > 0
+        assert "byok_rag" in config_data, "BYOK config (byok_rag) not found in /v1/config response"
+
+    def test_base_vector_db_retrieval(self, base_url, byok_provider_setup):
+        """Standard AAP RAG is still active when BYOK is enabled."""
+        query_data = {
+            "query": "What is AAP?",
+            "model": byok_provider_setup["model"],
+            "provider": byok_provider_setup["provider"],
+        }
+
+        response = requests.post(
+            f"{base_url}/v1/query",
+            json=query_data,
+            headers={"Content-Type": "application/json"},
+            timeout=120,
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.text}"
+        )
+
+        response_data = response.json()
+        response_text = (
+            response_data.get("response")
+            or response_data.get("answer")
+            or response_data.get("text")
+            or response_data.get("result", "")
+        )
+
+        assert isinstance(response_text, str), (
+            f"Unexpected response shape: {type(response_text)} — keys: {list(response_data.keys())}"
+        )
+        assert len(response_text) > 0, "Response should not be empty"
+        content_lower = response_text.lower()
+        assert any(
+            kw in content_lower
+            for kw in ["ansible automation platform", "aap", "ansible", "automation"]
+        ), f"Response should mention Ansible or AAP. Got: {response_text[:200]}"
+
+    def test_byok_vector_db_retrieval(self, base_url, byok_provider_setup):
+        """BYOK vector DB content is retrieved when queried."""
+        query_data = {
+            "query": "What is AnsibleByokPlugin?",
+            "model": byok_provider_setup["model"],
+            "provider": byok_provider_setup["provider"],
+        }
+
+        response = requests.post(
+            f"{base_url}/v1/query",
+            json=query_data,
+            headers={"Content-Type": "application/json"},
+            timeout=120,
+        )
+
+        assert response.status_code == 200, (
+            f"Expected 200, got {response.status_code}: {response.text}"
+        )
+
+        response_data = response.json()
+        response_text = (
+            response_data.get("response")
+            or response_data.get("answer")
+            or response_data.get("text")
+            or response_data.get("result", "")
+        )
+
+        assert isinstance(response_text, str), (
+            f"Unexpected response shape: {type(response_text)} — keys: {list(response_data.keys())}"
+        )
+        assert len(response_text) > 0, "Response should not be empty"
+        content_lower = response_text.lower()
+        assert any(
+            kw in content_lower
+            for kw in ["ansiblebyokplugin", "byok", "plugin", "fictional", "custom"]
+        ), (
+            f"Response should reference BYOK plugin content. Got: {response_text[:200]}"
+        )
+
+    def test_streaming_with_byok(self, base_url, byok_provider_setup):
+        """Streaming queries work correctly with BYOK enabled."""
+        query_data = {
+            "query": "What is AAP?",
+            "model": byok_provider_setup["model"],
+            "provider": byok_provider_setup["provider"],
+        }
+
+        response = requests.post(
+            f"{base_url}/v1/streaming_query",
+            json=query_data,
+            headers={"Content-Type": "application/json"},
+            stream=True,
+            timeout=120,
+        )
+
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+
+        full_response = ""
+        chunks_received = 0
+        non_token_events = []
+
+        for line in response.iter_lines():
+            if line:
+                line_str = line.decode("utf-8")
+                if line_str.startswith("data: "):
+                    chunks_received += 1
+                    try:
+                        chunk_data = json.loads(line_str[6:])
+                        if chunk_data.get("event") == "token":
+                            full_response += chunk_data.get("data", {}).get("token", "")
+                        else:
+                            non_token_events.append(chunk_data)
+                    except (json.JSONDecodeError, AttributeError):
+                        pass
+
+        assert chunks_received > 0, "Should receive at least one streaming chunk"
+        assert len(full_response) > 0, (
+            f"Streamed response should not be empty. "
+            f"Non-token events received: {non_token_events}"
+        )

--- a/tests/setup_test_data.py
+++ b/tests/setup_test_data.py
@@ -145,35 +145,131 @@ def setup_vector_db(target_dir: Path, model, provider_id: str):
     return provider_id
 
 
+def setup_byok_vector_db(target_dir: Path, model, vector_store_id: str):
+    """
+    Create a minimal BYOK FAISS vector database for sanity testing.
+
+    Uses identical SQLite kvstore format as setup_vector_db() but with
+    distinctive content that the standard AAP docs do not contain, so
+    test_byok_vector_db_retrieval can verify BYOK retrieval specifically.
+    """
+    import faiss
+    import numpy as np
+
+    print(f"📦 Creating BYOK vector database in {target_dir}...")
+
+    documents = [
+        {
+            "content": "AnsibleByokPlugin is a fictional automation plugin used exclusively for BYOK sanity testing.",
+            "metadata": {"source": "byok-test", "chunk_id": "0"}
+        },
+        {
+            "content": "The AnsibleByokPlugin integrates custom knowledge sources into ansible-chatbot-stack via BYOK.",
+            "metadata": {"source": "byok-test", "chunk_id": "1"}
+        },
+        {
+            "content": "AnsibleByokPlugin version 1.0 supports real-time event processing and dynamic knowledge retrieval.",
+            "metadata": {"source": "byok-test", "chunk_id": "2"}
+        },
+    ]
+
+    texts = [doc["content"] for doc in documents]
+    embeddings = model.encode(texts)
+
+    dimension = embeddings.shape[1]
+    index = faiss.IndexFlatL2(dimension)
+    index.add(embeddings.astype(np.float32))
+
+    faiss_bytes = faiss.serialize_index(index)
+
+    target_dir.mkdir(parents=True, exist_ok=True)
+    db_path = target_dir / "faiss_store.db"
+
+    if db_path.exists():
+        db_path.unlink()
+
+    with sqlite3.connect(str(db_path)) as conn:
+        cursor = conn.cursor()
+
+        cursor.execute("""
+            CREATE TABLE IF NOT EXISTS kvstore (
+                key TEXT PRIMARY KEY,
+                value BLOB
+            )
+        """)
+
+        cursor.execute(
+            "INSERT OR REPLACE INTO kvstore (key, value) VALUES (?, ?)",
+            (f"{vector_store_id}:faiss_index", faiss_bytes.tobytes())
+        )
+
+        for i, doc in enumerate(documents):
+            chunk_key = f"{vector_store_id}:chunk:{i}"
+            chunk_data = {
+                "content": doc["content"],
+                "metadata": doc["metadata"],
+                "embedding_index": i
+            }
+            cursor.execute(
+                "INSERT OR REPLACE INTO kvstore (key, value) VALUES (?, ?)",
+                (chunk_key, pickle.dumps(chunk_data))
+            )
+
+        db_metadata = {
+            "num_chunks": len(documents),
+            "dimension": dimension,
+            "provider_id": vector_store_id
+        }
+        cursor.execute(
+            "INSERT OR REPLACE INTO kvstore (key, value) VALUES (?, ?)",
+            (f"{vector_store_id}:metadata", pickle.dumps(db_metadata))
+        )
+
+    (target_dir / "provider_vector_db_id.ind").write_text(vector_store_id)
+
+    print(f"✅ BYOK vector database created: {db_path}")
+    print(f"   - {len(documents)} documents indexed")
+    print(f"   - Embedding dimension: {dimension}")
+    print(f"   - Vector store ID: {vector_store_id}")
+
+    return vector_store_id
+
+
 def main():
     """Main entry point."""
     # Determine project root
     script_dir = Path(__file__).parent
     project_root = script_dir.parent
-    
+
     embeddings_dir = project_root / "embeddings_model"
     vector_db_dir = project_root / "vector_db"
-    
+    byok_vector_db_dir = project_root / "byok_vector_db"
+
     # Provider ID that matches the test config
     provider_id = "aap-product-docs-2_6"
-    
+    byok_vector_store_id = "byok-sanity-test-0001"
+
     # Check if already set up
-    if embeddings_dir.exists() and vector_db_dir.exists():
+    if embeddings_dir.exists() and vector_db_dir.exists() and byok_vector_db_dir.exists():
         print("✅ Test data already exists. Use --force to recreate.")
         if "--force" not in sys.argv:
             return 0
         print("🔄 Recreating test data...")
-    
+
     # Setup embeddings model
     model = setup_embeddings_model(embeddings_dir)
-    
+
     # Setup vector database
     setup_vector_db(vector_db_dir, model, provider_id)
-    
+
+    # Setup BYOK vector database
+    setup_byok_vector_db(byok_vector_db_dir, model, byok_vector_store_id)
+
     print("\n✅ Test data setup complete!")
     print(f"   Embeddings model: {embeddings_dir}")
     print(f"   Vector database: {vector_db_dir}")
-    
+    print(f"   BYOK vector database: {byok_vector_db_dir}")
+
     return 0
 
 


### PR DESCRIPTION
## Summary

- Adds `tests/sanity/test_byok.py` with BYOK-specific end-to-end tests: server health, standard AAP RAG retrieval, BYOK vector DB retrieval, and streaming with BYOK enabled
- Extends `tests/sanity/conftest.py` with a `byok_provider_setup` fixture that mounts the BYOK vector DB and uses `byok-lightspeed-stack.yaml`
- Adds `tests/sanity/byok-lightspeed-stack.yaml` with dual vector store configuration
- Extends `tests/setup_test_data.py` to create a BYOK test vector DB with a fictional `AnsibleByokPlugin` document
- Adds `make test-sanity-byok` target and `byok` pytest marker

## Test plan

- [ ] `make test-sanity-byok` passes with at least one provider's credentials set
- [ ] `pytest tests/sanity/ -v -m byok` with no credentials shows all tests as `SKIPPED`
- [ ] `test_byok_vector_db_retrieval` returns content referencing the BYOK plugin document

Assisted-by: Claude Code / Sonnet 4.6 (Anthropic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)