### PR TITLE
Raise stale floors on 2 packages [lship]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "sentence-transformers>=5.2.0",
     "transformers>=5.5.0", # Transient dep pinned to handle CVE
     "starlette>=1.3.1",  # Bumped for CVE-2026-54283
-    "joserfc>=1.6.7", # Transient dep from authlib, pinned for CVE-2026-48990
+    "joserfc>=1.6.8", # Transient dep from authlib, pinned for CVE-2026-48990
     "urllib3==2.7.0",
 ]
 
@@ -34,7 +34,7 @@ dev = [
 test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
-    "requests>=2.31.0",
+    "requests>=2.33.0",
 ]
 
 [tool.pytest.ini_options]

--- a/uv.lock
+++ b/uv.lock
@@ -200,7 +200,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=50.0.0,<51" },
     { name = "dumb-init", specifier = ">=1.2.5.post1" },
     { name = "faiss-cpu", specifier = "==1.12" },
-    { name = "joserfc", specifier = ">=1.6.7" },
+    { name = "joserfc", specifier = ">=1.6.8" },
     { name = "lightspeed-stack-providers", specifier = "==0.4.3" },
     { name = "litellm", specifier = "==1.96.2" },
     { name = "mcp", specifier = ">=1.28.1,<2" },
@@ -225,7 +225,7 @@ dev = [
 test = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
-    { name = "requests", specifier = ">=2.31.0" },
+    { name = "requests", specifier = ">=2.33.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Stale declarations

2 declaration(s) sit below the fixed version, but the package is
already constrained safely elsewhere in the same project — the resolved version
does not change. Raising the declared floors keeps a later refactor from
silently reintroducing the vulnerable range.

- `joserfc` (.) 1.6.7 → 1.6.8 (CVE-2026-49852, GHSA-gg9x-qcx2-xmrh, PYSEC-2026-2528)

- `requests` (.) 2.31.0 → 2.33.0 (CVE-2024-47081, GHSA-9hjg-9r4m-mvj7, CVE-2024-35195, GHSA-9wx4-h78v-vm56, CVE-2026-25645, GHSA-gc5v-m9x4-r6x2, PYSEC-2026-1872, PYSEC-2026-1873, PYSEC-2026-2275)







## Fixes lship refused to apply

A fix exists for each of these, and applying it automatically would cross a
major-version boundary or breach a cap this project declares. Each needs its
own migration PR — this one does not address them:

- `pytest` (.) 8.0.0 → 9.0.3 (CVE-2025-71176, GHSA-6w46-j5rx-g56g, PYSEC-2026-1845) — major bump




## Test plan
- [ ] CI passes
- [ ] `uv lock --check` / `uv pip compile` resolves successfully

<!-- lship:{"operation_hash":"8d4ef13e6bdec92c","trackers":[{"cve_ids":["CVE-2026-25211","GHSA-xmfj-7pp5-fxr6","PYSEC-2026-1572"],"package":"llama-stack","current_version":"0.4.3","fixed_version":"0.4.4"},{"cve_ids":["CVE-2026-49852","GHSA-gg9x-qcx2-xmrh","PYSEC-2026-2528"],"package":"joserfc","current_version":"1.6.7","fixed_version":"1.6.8"},{"cve_ids":["CVE-2025-71176","GHSA-6w46-j5rx-g56g","PYSEC-2026-1845"],"package":"pytest","current_version":"8.0.0","fixed_version":"9.0.3"},{"cve_ids":["CVE-2024-47081","GHSA-9hjg-9r4m-mvj7","CVE-2024-35195","GHSA-9wx4-h78v-vm56","CVE-2026-25645","GHSA-gc5v-m9x4-r6x2","PYSEC-2026-1872","PYSEC-2026-1873","PYSEC-2026-2275"],"package":"requests","current_version":"2.31.0","fixed_version":"2.33.0"}]} -->