### PR TITLE
Add Vertex AI provider support to sanity tests

### DIFF
--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -33,6 +33,13 @@ jobs:
       AZURE_OPENAI_BASE_URL: ${{ secrets.SANITY_AZURE_OPENAI_BASE_URL }}
       AZURE_OPENAI_API_KEY: ${{ secrets.SANITY_AZURE_OPENAI_API_KEY }}
       AZURE_OPENAI_INFERENCE_MODEL: ${{ secrets.SANITY_AZURE_OPENAI_INFERENCE_MODEL }}
+      # Vertex AI — tests skip if these are empty. VERTEX_AI_CREDENTIALS is the
+      # service-account JSON; the sanity fixtures write it to a temp file and set
+      # GOOGLE_APPLICATION_CREDENTIALS to that path.
+      VERTEX_AI_CREDENTIALS: ${{ secrets.SANITY_VERTEX_AI_CREDENTIALS }}
+      VERTEX_AI_PROJECT: ${{ secrets.SANITY_VERTEX_AI_PROJECT }}
+      VERTEX_AI_LOCATION: ${{ secrets.SANITY_VERTEX_AI_LOCATION }}
+      VERTEX_AI_INFERENCE_MODEL: ${{ secrets.SANITY_VERTEX_AI_INFERENCE_MODEL }}
       # MCP servers — pinning these means _skip_or_fail_unpullable (conftest.py) fails
       # the build rather than skipping if the images cannot be pulled; see the Quay
       # login step below.
@@ -56,7 +63,7 @@ jobs:
 
       - name: Fail if no providers configured
         run: |
-          if [ -z "$VLLM_URL" ] && [ -z "$OPENAI_API_KEY" ] && [ -z "$AZURE_OPENAI_BASE_URL" ]; then
+          if [ -z "$VLLM_URL" ] && [ -z "$OPENAI_API_KEY" ] && [ -z "$AZURE_OPENAI_BASE_URL" ] && [ -z "$VERTEX_AI_CREDENTIALS" ]; then
             echo "::error::No sanity provider credentials configured — nothing will be tested"
             exit 1
           fi
@@ -151,6 +158,7 @@ jobs:
           echo "| Granite (vLLM) | ${{ secrets.SANITY_VLLM_URL != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| OpenAI | ${{ secrets.SANITY_OPENAI_API_KEY != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Azure OpenAI | ${{ secrets.SANITY_AZURE_OPENAI_BASE_URL != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Vertex AI | ${{ secrets.SANITY_VERTEX_AI_PROJECT != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### MCP images" >> $GITHUB_STEP_SUMMARY
           echo "| Image | Pull status |" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/test-sanity.yml
+++ b/.github/workflows/test-sanity.yml
@@ -63,7 +63,8 @@ jobs:
 
       - name: Fail if no providers configured
         run: |
-          if [ -z "$VLLM_URL" ] && [ -z "$OPENAI_API_KEY" ] && [ -z "$AZURE_OPENAI_BASE_URL" ] && [ -z "$VERTEX_AI_CREDENTIALS" ]; then
+          if [ -z "$VLLM_URL" ] && [ -z "$OPENAI_API_KEY" ] && [ -z "$AZURE_OPENAI_BASE_URL" ] \
+              && { [ -z "$VERTEX_AI_CREDENTIALS" ] || [ -z "$VERTEX_AI_PROJECT" ]; }; then
             echo "::error::No sanity provider credentials configured — nothing will be tested"
             exit 1
           fi
@@ -158,7 +159,7 @@ jobs:
           echo "| Granite (vLLM) | ${{ secrets.SANITY_VLLM_URL != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| OpenAI | ${{ secrets.SANITY_OPENAI_API_KEY != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "| Azure OpenAI | ${{ secrets.SANITY_AZURE_OPENAI_BASE_URL != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Vertex AI | ${{ secrets.SANITY_VERTEX_AI_PROJECT != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Vertex AI | ${{ secrets.SANITY_VERTEX_AI_CREDENTIALS != '' && '✅' || '⚠️ skipped' }} |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### MCP images" >> $GITHUB_STEP_SUMMARY
           echo "| Image | Pull status |" >> $GITHUB_STEP_SUMMARY

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,7 @@ help:
 	@echo "  test-sanity-granite - Run Granite/vLLM sanity tests"
 	@echo "  test-sanity-openai  - Run real OpenAI sanity tests"
 	@echo "  test-sanity-azure   - Run Azure OpenAI sanity tests"
+	@echo "  test-sanity-vertexai - Run Google Vertex AI sanity tests"
 	@echo "  test-sanity-byok    - Run BYOK sanity tests (requires inference provider env vars)"
 	@echo "  test-sanity-mcp     - Run MCP sanity tests (requires inference provider env vars + MCP images)"
 	@echo "                        Set MCP_DEBUG=1 to print tool-filter before/after counts"
@@ -313,6 +314,10 @@ test-sanity-openai:
 test-sanity-azure:
 	@echo "Running Azure OpenAI sanity tests (requires AZURE_OPENAI_BASE_URL, AZURE_OPENAI_API_KEY, AZURE_OPENAI_INFERENCE_MODEL)..."
 	uv run --frozen --group test pytest tests/sanity/ -v -m azure
+
+test-sanity-vertexai:
+	@echo "Running Vertex AI sanity tests (requires VERTEX_AI_CREDENTIALS, VERTEX_AI_PROJECT)..."
+	uv run --frozen --group test pytest tests/sanity/ -v -m vertexai
 
 test-sanity-byok:
 	@echo "Running BYOK sanity tests (requires inference provider env vars + .test_data/byok_vector_db/)..."

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Run a single provider:
     # Vertex AI
     export VERTEX_AI_CREDENTIALS='<SERVICE_ACCOUNT_JSON>'
     export VERTEX_AI_PROJECT=<YOUR_GCP_PROJECT>
-    # optional: VERTEX_AI_LOCATION (default: global)
+    # optional: VERTEX_AI_LOCATION (default: us-central1)
     # optional: VERTEX_AI_INFERENCE_MODEL (default: google/gemini-2.5-pro)
     make test-sanity-vertexai
 ```

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ Tests for a given provider are skipped automatically when the required environme
 | Granite (vLLM) | `make test-sanity-granite` | `VLLM_URL`, `VLLM_API_TOKEN`, `INFERENCE_MODEL` |
 | OpenAI | `make test-sanity-openai` | `OPENAI_API_KEY`, `OPENAI_INFERENCE_MODEL` |
 | Azure OpenAI | `make test-sanity-azure` | `AZURE_OPENAI_BASE_URL`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_INFERENCE_MODEL` |
+| Vertex AI | `make test-sanity-vertexai` | `VERTEX_AI_CREDENTIALS`, `VERTEX_AI_PROJECT` |
 
 ### Prerequisites
 
@@ -197,6 +198,13 @@ Run a single provider:
     export AZURE_OPENAI_API_KEY=<YOUR_AZURE_API_KEY>
     export AZURE_OPENAI_INFERENCE_MODEL=<YOUR_DEPLOYMENT_NAME>
     make test-sanity-azure
+
+    # Vertex AI
+    export VERTEX_AI_CREDENTIALS='<SERVICE_ACCOUNT_JSON>'
+    export VERTEX_AI_PROJECT=<YOUR_GCP_PROJECT>
+    # optional: VERTEX_AI_LOCATION (default: global)
+    # optional: VERTEX_AI_INFERENCE_MODEL (default: google/gemini-2.5-pro)
+    make test-sanity-vertexai
 ```
 
 ### MCP sanity tests
@@ -269,6 +277,7 @@ Provider credentials are stored as repository secrets with a `SANITY_` prefix:
 | `SANITY_VLLM_URL`, `SANITY_VLLM_API_TOKEN`, `SANITY_INFERENCE_MODEL` | Granite (vLLM) |
 | `SANITY_OPENAI_API_KEY`, `SANITY_OPENAI_INFERENCE_MODEL` | OpenAI |
 | `SANITY_AZURE_OPENAI_BASE_URL`, `SANITY_AZURE_OPENAI_API_KEY`, `SANITY_AZURE_OPENAI_INFERENCE_MODEL` | Azure OpenAI |
+| `SANITY_VERTEX_AI_CREDENTIALS`, `SANITY_VERTEX_AI_PROJECT` | Vertex AI |
 
 Providers whose secrets are absent are skipped rather than failed.
 The workflow also pulls the MCP server images; MCP tests skip if a pull fails.

--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ Run a single provider:
     make test-sanity-vertexai
 ```
 
+**Note:** In Llama Stack versions 0.4 through 0.5, the Vertex AI provider hardcodes support to the following three
+models:
+- `google/gemini-2.0-flash`
+- `google/gemini-2.5-flash`
+- `google/gemini-2.5-pro`
+
 ### MCP sanity tests
 
 These start real Automation Controller and Lightspeed MCP servers against a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
 [dependency-groups]
 dev = [
     "cachetools>=6.1.0",
-    "google-auth[requests]>=2.40.0",  # Vertex AI ADC for sanity tests
     "kubernetes>=33.1.0",
     "locust>=2.39.1",
     "pre-commit>=4.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "cachetools>=6.1.0",
+    "google-auth[requests]>=2.40.0",  # Vertex AI ADC for sanity tests
     "kubernetes>=33.1.0",
     "locust>=2.39.1",
     "pre-commit>=4.2.0",
@@ -42,6 +43,7 @@ markers = [
     "granite: tests using the in-house Granite LLM via vLLM (requires VLLM_URL, VLLM_API_TOKEN, INFERENCE_MODEL)",
     "openai: tests using the real OpenAI API (requires OPENAI_API_KEY, OPENAI_INFERENCE_MODEL)",
     "azure: tests using Azure OpenAI (requires AZURE_OPENAI_BASE_URL, AZURE_OPENAI_API_KEY, AZURE_OPENAI_INFERENCE_MODEL)",
+    "vertexai: tests using Google Vertex AI (requires VERTEX_AI_CREDENTIALS, VERTEX_AI_PROJECT)",
     "byok: tests using BYOK (Bring Your Own Knowledge) vector database alongside the standard AAP RAG",
     "mcp: tests using controller and lightspeed MCP servers against a mock AAP",
 ]

--- a/tests/sanity/conftest.py
+++ b/tests/sanity/conftest.py
@@ -122,8 +122,17 @@ def _unlink_quietly(path):
         pass
 
 
+# Prior value of GOOGLE_APPLICATION_CREDENTIALS (if any) keyed by the ADC temp file
+# path that shadowed it, so _cleanup_vertex_adc_file can restore rather than drop it.
+_PRIOR_GOOGLE_ADC = {}
+
+
 def _write_vertex_adc_file():
-    """Write VERTEX_AI_CREDENTIALS to a 0600 temp file and export its path as ADC.
+    """Write VERTEX_AI_CREDENTIALS to a temp file and export its path as ADC.
+
+    The file is created 0644 (not 0600) because the container may read it as a uid
+    unrelated to the host user: podman gets a --userns keep-id mapping to the host
+    uid, but docker does not, so the container's baked-in uid needs world-read.
 
     The caller must invoke _cleanup_vertex_adc_file on the returned path.
     """
@@ -134,15 +143,20 @@ def _write_vertex_adc_file():
         creds_file.write(os.environ["VERTEX_AI_CREDENTIALS"])
     finally:
         creds_file.close()
-    os.chmod(creds_file.name, 0o600)
+    os.chmod(creds_file.name, 0o644)
+    _PRIOR_GOOGLE_ADC[creds_file.name] = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
     os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = creds_file.name
     return creds_file.name
 
 
 def _cleanup_vertex_adc_file(path):
-    """Delete the ADC temp file and drop GOOGLE_APPLICATION_CREDENTIALS if it points at it."""
+    """Delete the ADC temp file and restore any prior GOOGLE_APPLICATION_CREDENTIALS."""
     if path and os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") == path:
-        del os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+        prior = _PRIOR_GOOGLE_ADC.pop(path, None)
+        if prior:
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = prior
+        else:
+            del os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
     _unlink_quietly(path)
 
 
@@ -229,6 +243,10 @@ def _build_mcp_provider_config(provider):
     _, env_overrides, config = _build_provider_config(provider)
     run_config = str(_SANITY_DIR / f"mcp-{provider}-chatbot-run.yaml")
     if not Path(run_config).exists():
+        # _build_provider_config may have already written a vertexai ADC file and
+        # exported GOOGLE_APPLICATION_CREDENTIALS — clean up before failing so the
+        # real credential doesn't outlive this fixture call.
+        _cleanup_vertex_adc_file(config.get("credentials_file"))
         pytest.fail(f"MCP run config not found: {run_config}")
     if os.environ.get("INFERENCE_MODEL_FILTER"):
         env_overrides["INFERENCE_MODEL_FILTER"] = os.environ["INFERENCE_MODEL_FILTER"]

--- a/tests/sanity/conftest.py
+++ b/tests/sanity/conftest.py
@@ -28,6 +28,9 @@ BASE_URL = "http://127.0.0.1:8322"
 _GRANITE_REQUIRED = ["VLLM_URL", "VLLM_API_TOKEN", "INFERENCE_MODEL"]
 _OPENAI_REQUIRED = ["OPENAI_API_KEY", "OPENAI_INFERENCE_MODEL"]
 _AZURE_REQUIRED = ["AZURE_OPENAI_BASE_URL", "AZURE_OPENAI_API_KEY", "AZURE_OPENAI_INFERENCE_MODEL"]
+_VERTEXAI_REQUIRED = ["VERTEX_AI_CREDENTIALS", "VERTEX_AI_PROJECT"]
+_VERTEXAI_DEFAULT_MODEL = "google/gemini-2.5-pro"
+_GOOGLE_ADC_CONTAINER_PATH = "/.llama/secrets/google-application-credentials.json"
 
 _SANITY_DIR = Path(__file__).parent
 _PROJECT_ROOT = _SANITY_DIR.parent.parent
@@ -110,6 +113,56 @@ def _check_required_vars(var_names):
         pytest.skip(f"Missing required environment variables: {', '.join(missing)}")
 
 
+def _unlink_quietly(path):
+    if not path:
+        return
+    try:
+        os.unlink(path)
+    except OSError:
+        pass
+
+
+def _write_vertex_adc_file():
+    """Write VERTEX_AI_CREDENTIALS to a 0600 temp file and export its path as ADC.
+
+    The caller must invoke _cleanup_vertex_adc_file on the returned path.
+    """
+    creds_file = tempfile.NamedTemporaryFile(
+        "w", suffix=".json", prefix="vertex-adc-", delete=False
+    )
+    try:
+        creds_file.write(os.environ["VERTEX_AI_CREDENTIALS"])
+    finally:
+        creds_file.close()
+    os.chmod(creds_file.name, 0o600)
+    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = creds_file.name
+    return creds_file.name
+
+
+def _cleanup_vertex_adc_file(path):
+    """Delete the ADC temp file and drop GOOGLE_APPLICATION_CREDENTIALS if it points at it."""
+    if path and os.environ.get("GOOGLE_APPLICATION_CREDENTIALS") == path:
+        del os.environ["GOOGLE_APPLICATION_CREDENTIALS"]
+    _unlink_quietly(path)
+
+
+def _google_adc_volume_mount(env_overrides):
+    """Point GOOGLE_APPLICATION_CREDENTIALS at a container path and return a volume spec.
+
+    Vertex AI uses Application Default Credentials from this file. The host path
+    is rewritten in env_overrides so the container sees the mounted location.
+    Returns None when the env var is not present.
+    """
+    host_path = env_overrides.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not host_path:
+        return None
+    creds = Path(host_path).expanduser()
+    if not creds.is_file():
+        pytest.fail(f"GOOGLE_APPLICATION_CREDENTIALS is not a file: {host_path}")
+    env_overrides["GOOGLE_APPLICATION_CREDENTIALS"] = _GOOGLE_ADC_CONTAINER_PATH
+    return f"{creds.resolve()}:{_GOOGLE_ADC_CONTAINER_PATH}:ro,z"
+
+
 def _build_provider_config(provider):
     """Return (run_config_path, env_overrides, config_dict) for the given provider."""
     if provider == "granite":
@@ -137,7 +190,7 @@ def _build_provider_config(provider):
         run_config = str(_SANITY_DIR / "openai-chatbot-run.yaml")
         config = {"model": os.environ["OPENAI_INFERENCE_MODEL"], "provider": "openai"}
 
-    else:  # azure
+    elif provider == "azure":
         _check_required_vars(_AZURE_REQUIRED)
         env_overrides = {
             "AZURE_OPENAI_BASE_URL": os.environ["AZURE_OPENAI_BASE_URL"],
@@ -146,6 +199,27 @@ def _build_provider_config(provider):
         }
         run_config = str(_SANITY_DIR / "azure-chatbot-run.yaml")
         config = {"model": os.environ["AZURE_OPENAI_INFERENCE_MODEL"], "provider": "openai_azure"}
+
+    elif provider == "vertexai":
+        _check_required_vars(_VERTEXAI_REQUIRED)
+        creds_path = _write_vertex_adc_file()
+        model = os.environ.get("VERTEX_AI_INFERENCE_MODEL") or _VERTEXAI_DEFAULT_MODEL
+        env_overrides = {
+            "GOOGLE_APPLICATION_CREDENTIALS": creds_path,
+            "VERTEX_AI_PROJECT": os.environ["VERTEX_AI_PROJECT"],
+            "VERTEX_AI_INFERENCE_MODEL": model,
+        }
+        if os.environ.get("VERTEX_AI_LOCATION"):
+            env_overrides["VERTEX_AI_LOCATION"] = os.environ["VERTEX_AI_LOCATION"]
+        run_config = str(_SANITY_DIR / "vertexai-chatbot-run.yaml")
+        config = {
+            "model": model,
+            "provider": "vertexai",
+            "credentials_file": creds_path,
+        }
+
+    else:
+        pytest.fail(f"Unknown sanity provider: {provider}")
 
     return run_config, env_overrides, config
 
@@ -179,6 +253,42 @@ def _validate_image_ref(image):
     if not _IMAGE_REF_RE.fullmatch(image) or ".." in image:
         pytest.fail(f"Invalid container image reference: {image!r}")
     return image
+
+
+def _model_ids_from_payload(payload):
+    """Extract model identifier strings from a /v1/models JSON payload."""
+    if isinstance(payload, dict):
+        items = payload.get("data") or payload.get("models") or []
+    elif isinstance(payload, list):
+        items = payload
+    else:
+        return []
+    ids = []
+    for item in items:
+        if isinstance(item, str):
+            ids.append(item)
+        elif isinstance(item, dict):
+            model_id = item.get("id") or item.get("model_id") or item.get("identifier")
+            if model_id:
+                ids.append(str(model_id))
+    return ids
+
+
+def _print_available_models(models_payload=None):
+    """Print model IDs from /v1/models so they show up next to the server-ready log."""
+    payload = models_payload
+    if payload is None:
+        try:
+            resp = requests.get(f"{BASE_URL}/v1/models", timeout=2)
+            if resp.status_code != 200:
+                return
+            payload = resp.json()
+        except (requests.exceptions.RequestException, ValueError):
+            return
+    model_ids = _model_ids_from_payload(payload)
+    if model_ids:
+        print("[✓] Models: " + ", ".join(model_ids))
+
 
 
 def _system_prompt_file_for(provider):
@@ -218,6 +328,10 @@ def _start_sanity_server(run_config_path, lightspeed_config_path, env_overrides,
                 f"not found in /v1/models. Stop the existing server first."
             )
         print(f"\n[✓] Chatbot server already running at {BASE_URL}")
+        try:
+            _print_available_models(models_resp.json())
+        except ValueError:
+            pass
         return None, None, None, None
 
     # Check prerequisites
@@ -274,6 +388,8 @@ def _start_sanity_server(run_config_path, lightspeed_config_path, env_overrides,
             pass
 
     # Write provider credentials to a 0600 temp file to keep secrets off argv
+    env_overrides = dict(env_overrides)
+    adc_mount = _google_adc_volume_mount(env_overrides)
     env_file = tempfile.NamedTemporaryFile("w", suffix=".env", delete=False)
     env_file_path = env_file.name
     try:
@@ -312,6 +428,10 @@ def _start_sanity_server(run_config_path, lightspeed_config_path, env_overrides,
         "--env", f"LOG_LEVEL={os.environ.get('LOG_LEVEL', 'INFO')}",
         "--env-file", env_file_path,
     ]
+    if os.environ.get("LLAMA_STACK_LOGGING"):
+        cmd += ["--env", f"LLAMA_STACK_LOGGING={os.environ['LLAMA_STACK_LOGGING']}"]
+    if adc_mount:
+        cmd += ["-v", adc_mount]
 
     if byok_vector_db_path:
         byok_vid_file = _TEST_DATA_DIR / byok_vector_db_path / _PROVIDER_VECTOR_DB_ID_FILE
@@ -385,6 +505,7 @@ def _start_sanity_server(run_config_path, lightspeed_config_path, env_overrides,
             if resp.status_code == 200:
                 elapsed = int(time.monotonic() - start)
                 print(f"[✓] Server ready ({elapsed}s)")
+                _print_available_models()
                 return process, container_runtime, container_name, env_file_path
         except requests.exceptions.RequestException:
             pass
@@ -769,6 +890,7 @@ def _reject_stale_server(context_message):
         pytest.param("granite", marks=pytest.mark.granite),
         pytest.param("openai", marks=pytest.mark.openai),
         pytest.param("azure", marks=pytest.mark.azure),
+        pytest.param("vertexai", marks=pytest.mark.vertexai),
     ],
     scope="module",
 )
@@ -781,18 +903,17 @@ def provider_setup(request):
     """
     provider = request.param
     run_config, env_overrides, config = _build_provider_config(provider)
-    process, runtime, name, env_file_path = _start_sanity_server(
-        run_config, _LIGHTSPEED_STACK_CONFIG, env_overrides, provider, config["model"]
-    )
+    credentials_file = config.pop("credentials_file", None)
+    process = runtime = name = env_file_path = None
     try:
+        process, runtime, name, env_file_path = _start_sanity_server(
+            run_config, _LIGHTSPEED_STACK_CONFIG, env_overrides, provider, config["model"]
+        )
         yield config
     finally:
         _stop_sanity_server(process, runtime, name)
-        if env_file_path:
-            try:
-                os.unlink(env_file_path)
-            except OSError:
-                pass
+        _unlink_quietly(env_file_path)
+        _cleanup_vertex_adc_file(credentials_file)
 
 
 @pytest.fixture(
@@ -800,6 +921,7 @@ def provider_setup(request):
         pytest.param("granite", marks=[pytest.mark.granite, pytest.mark.byok]),
         pytest.param("openai", marks=[pytest.mark.openai, pytest.mark.byok]),
         pytest.param("azure", marks=[pytest.mark.azure, pytest.mark.byok]),
+        pytest.param("vertexai", marks=[pytest.mark.vertexai, pytest.mark.byok]),
     ],
     scope="module",
 )
@@ -817,26 +939,24 @@ def byok_provider_setup(request):
     # check below: it's what lets a param with missing credentials skip cleanly
     # rather than hit the hard pytest.fail() below for an unrelated reason.
     run_config, env_overrides, config = _build_provider_config(provider)
-
-    _reject_stale_server(
-        "_start_sanity_server's reuse check only verifies the model name, not that "
-        "BYOK config is mounted — stop the existing server before BYOK sanity tests."
-    )
-
-    process, runtime, name, env_file_path = _start_sanity_server(
-        run_config, _BYOK_LIGHTSPEED_STACK_CONFIG, env_overrides,
-        provider=f"byok-{provider}", expected_model=config["model"],
-        byok_vector_db_path="byok_vector_db",
-    )
+    credentials_file = config.pop("credentials_file", None)
+    process = runtime = name = env_file_path = None
     try:
+        _reject_stale_server(
+            "_start_sanity_server's reuse check only verifies the model name, not that "
+            "BYOK config is mounted — stop the existing server before BYOK sanity tests."
+        )
+
+        process, runtime, name, env_file_path = _start_sanity_server(
+            run_config, _BYOK_LIGHTSPEED_STACK_CONFIG, env_overrides,
+            provider=f"byok-{provider}", expected_model=config["model"],
+            byok_vector_db_path="byok_vector_db",
+        )
         yield config
     finally:
         _stop_sanity_server(process, runtime, name)
-        if env_file_path:
-            try:
-                os.unlink(env_file_path)
-            except OSError:
-                pass
+        _unlink_quietly(env_file_path)
+        _cleanup_vertex_adc_file(credentials_file)
 
 
 @pytest.fixture(
@@ -844,6 +964,7 @@ def byok_provider_setup(request):
         pytest.param("granite", marks=[pytest.mark.granite, pytest.mark.mcp]),
         pytest.param("openai", marks=[pytest.mark.openai, pytest.mark.mcp]),
         pytest.param("azure", marks=[pytest.mark.azure, pytest.mark.mcp]),
+        pytest.param("vertexai", marks=[pytest.mark.vertexai, pytest.mark.mcp]),
     ],
     scope="module",
 )
@@ -859,13 +980,14 @@ def mcp_provider_setup(request):
     # check below: it's what lets a param with missing credentials skip cleanly
     # rather than hit the hard pytest.fail() below for an unrelated reason.
     run_config, env_overrides, config = _build_mcp_provider_config(provider)
-
-    _reject_stale_server("Stop it before MCP sanity tests so MCP sidecars can be attached.")
-
-    mock_aap = _start_mock_aap_for_sanity()
+    credentials_file = config.pop("credentials_file", None)
+    mock_aap = None
     mcp_handles = []
     process = runtime = name = env_file_path = None
     try:
+        _reject_stale_server("Stop it before MCP sanity tests so MCP sidecars can be attached.")
+
+        mock_aap = _start_mock_aap_for_sanity()
         mcp_handles = _start_mcp_servers(mock_aap.url)
         process, runtime, name, env_file_path = _start_sanity_server(
             run_config, _MCP_LIGHTSPEED_STACK_CONFIG, env_overrides,
@@ -876,13 +998,11 @@ def mcp_provider_setup(request):
         yield config
     finally:
         _stop_sanity_server(process, runtime, name)
-        if env_file_path:
-            try:
-                os.unlink(env_file_path)
-            except OSError:
-                pass
+        _unlink_quietly(env_file_path)
+        _cleanup_vertex_adc_file(credentials_file)
         _stop_mcp_servers(mcp_handles)
-        mock_aap.stop()
+        if mock_aap is not None:
+            mock_aap.stop()
 
 
 @pytest.fixture(scope="session")

--- a/tests/sanity/mcp-vertexai-chatbot-run.yaml
+++ b/tests/sanity/mcp-vertexai-chatbot-run.yaml
@@ -1,0 +1,152 @@
+version: '2'
+image_name: ansible-chatbot-sanity-mcp-vertexai
+container_image: ansible-chatbot-sanity-mcp-vertexai
+apis:
+- inference
+- vector_io
+- safety
+- agents
+- datasetio
+- tool_runtime
+- files
+providers:
+  inference:
+  - provider_id: vertexai
+    provider_type: remote::vertexai
+    config:
+      project: ${env.VERTEX_AI_PROJECT:=}
+      location: ${env.VERTEX_AI_LOCATION:=global}
+  - provider_id: sentence-transformers
+    provider_type: inline::sentence-transformers
+    config: {}
+  vector_io:
+  - provider_id: aap_faiss
+    provider_type: inline::faiss
+    config:
+      persistence:
+        namespace: vector_io::faiss
+        backend: kv_rag
+  safety:
+  - provider_id: llama-guard
+    provider_type: inline::llama-guard
+    config:
+      excluded_categories: []
+  agents:
+  - provider_id: lightspeed_inline_agent
+    provider_type: inline::lightspeed_inline_agent
+    config:
+      persistence:
+        agent_state:
+          namespace: agents_state
+          backend: kv_default
+        responses:
+          table_name: agent_responses
+          backend: sql_default
+      tools_filter:
+        enabled: true
+        model_id: ${env.INFERENCE_MODEL_FILTER:=}
+        always_include_tools:
+        - knowledge_search
+  datasetio:
+  - provider_id: localfs
+    provider_type: inline::localfs
+    config:
+      kvstore:
+        namespace: localfs_datasetio
+        backend: kv_default
+  files:
+  - provider_id: meta-reference-files
+    provider_type: inline::localfs
+    config:
+      storage_dir: ${env.PROVIDERS_DB_DIR:=./test_data}/files
+      metadata_store:
+        table_name: files_metadata
+        backend: sql_default
+  tool_runtime:
+  - provider_id: rag-runtime
+    provider_type: inline::rag-runtime
+    config: {}
+  - provider_id: model-context-protocol
+    provider_type: remote::model-context-protocol
+    config: {}
+storage:
+  backends:
+    kv_rag:
+      type: kv_sqlite
+      db_path: ${env.VECTOR_DB_DIR:=./test_data}/aap_faiss_store.db
+    kv_default:
+      type: kv_sqlite
+      db_path: ${env.KV_STORE_DB_DIR:=./test_data}/kv_store.db
+    sql_default:
+      type: sql_sqlite
+      db_path: ${env.SQL_STORE_DB_DIR:=./test_data}/sql_store.db
+  stores:
+    metadata:
+      namespace: registry
+      backend: kv_default
+    inference:
+      table_name: inference_store
+      backend: sql_default
+      max_write_queue_size: 10000
+      num_writers: 4
+    conversations:
+      table_name: openai_conversations
+      backend: sql_default
+    prompts:
+      namespace: prompts
+      backend: kv_default
+registered_resources:
+  models:
+    - metadata: {}
+      model_id: ${env.VERTEX_AI_INFERENCE_MODEL:=google/gemini-2.5-pro}
+      provider_id: vertexai
+      provider_model_id: ${env.VERTEX_AI_INFERENCE_MODEL:=google/gemini-2.5-pro}
+    - metadata:
+        embedding_dimension: 384
+      model_id: sentence-transformers/all-mpnet-base-v2
+      provider_id: sentence-transformers
+      provider_model_id: ${env.EMBEDDINGS_MODEL:=/.llama/data/embeddings_model}
+      model_type: embedding
+  shields: []
+  vector_stores:
+    - metadata: {}
+      vector_store_id: ${env.PROVIDER_VECTOR_DB_ID:=}
+      embedding_model: sentence-transformers/${env.EMBEDDINGS_MODEL:=/.llama/data/embeddings_model}
+      embedding_dimension: 384
+      provider_id: aap_faiss
+  datasets: []
+  scoring_fns: []
+  benchmarks: []
+  tool_groups:
+    - toolgroup_id: builtin::rag
+      provider_id: rag-runtime
+    - toolgroup_id: mcp::aap-controller
+      provider_id: model-context-protocol
+      mcp_endpoint:
+        uri: http://localhost:8004/sse
+    - toolgroup_id: mcp::aap-lightspeed
+      provider_id: model-context-protocol
+      mcp_endpoint:
+        uri: http://localhost:8005/sse
+  safety:
+    - default_shield_id: llama-guard
+vector_stores:
+  default_provider_id: aap_faiss
+  default_embedding_model:
+    provider_id: sentence-transformers
+    model_id: /.llama/data/embeddings_model
+  annotation_prompt_params:
+    enable_annotations: true
+    annotation_instruction_template: >
+      When appropriate, cite sources at the end of sentences using doc_url and doc_title format.
+      Citing sources is not always required because citations are handled externally.
+      Never include any citation that is in the form '<| file-id |>'.
+logging: null
+server:
+  port: 8322
+  tls_certfile: null
+  tls_keyfile: null
+  tls_cafile: null
+  auth: null
+  disable_ipv6: false
+external_providers_dir: ${env.EXTERNAL_PROVIDERS_DIR:=/.llama/providers.d}

--- a/tests/sanity/mcp-vertexai-chatbot-run.yaml
+++ b/tests/sanity/mcp-vertexai-chatbot-run.yaml
@@ -15,7 +15,7 @@ providers:
     provider_type: remote::vertexai
     config:
       project: ${env.VERTEX_AI_PROJECT:=}
-      location: ${env.VERTEX_AI_LOCATION:=global}
+      location: ${env.VERTEX_AI_LOCATION:=us-central1}
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config: {}

--- a/tests/sanity/test_byok.py
+++ b/tests/sanity/test_byok.py
@@ -6,6 +6,7 @@ Tests run for each provider configured via the byok_provider_setup fixture:
   - OpenAI          — requires OPENAI_API_KEY, OPENAI_INFERENCE_MODEL
   - Azure OpenAI    — requires AZURE_OPENAI_BASE_URL, AZURE_OPENAI_API_KEY,
                                AZURE_OPENAI_INFERENCE_MODEL
+  - Vertex AI       — requires VERTEX_AI_CREDENTIALS, VERTEX_AI_PROJECT
 
 A provider is skipped automatically when its required variables are not set.
 The BYOK vector DB must exist at .test_data/byok_vector_db/ (created by 'make setup-sanity-test-data').

--- a/tests/sanity/test_providers.py
+++ b/tests/sanity/test_providers.py
@@ -175,7 +175,6 @@ class TestChatbotSanity:
         )
 
 
-@pytest.mark.vertexai
 def test_vertexai_run_config():
     """Vertex AI sanity run configs must declare the provider, ADC project/location, and default model."""
     sanity_dir = Path(__file__).parent
@@ -184,7 +183,7 @@ def test_vertexai_run_config():
         assert "provider_id: vertexai" in text, name
         assert "provider_type: remote::vertexai" in text, name
         assert "project: ${env.VERTEX_AI_PROJECT:=}" in text, name
-        assert "location: ${env.VERTEX_AI_LOCATION:=global}" in text, name
+        assert "location: ${env.VERTEX_AI_LOCATION:=us-central1}" in text, name
         assert "google/gemini-2.5-pro" in text, name
 
 
@@ -199,7 +198,6 @@ def test_vertexai_provider_config_skipped_without_credentials(monkeypatch):
         _build_provider_config("vertexai")
 
 
-@pytest.mark.vertexai
 def test_vertexai_provider_config_defaults(monkeypatch):
     payload = '{"type":"service_account","project_id":"sanity-vertex-project"}'
     monkeypatch.setenv("VERTEX_AI_CREDENTIALS", payload)
@@ -217,6 +215,7 @@ def test_vertexai_provider_config_defaults(monkeypatch):
 
     run_config, env_overrides, config = _build_provider_config("vertexai")
     creds_path = config.pop("credentials_file")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", creds_path)
     try:
         assert run_config.endswith("vertexai-chatbot-run.yaml")
         assert config == {"model": _VERTEXAI_DEFAULT_MODEL, "provider": "vertexai"}
@@ -236,6 +235,6 @@ def test_vertexai_provider_config_defaults(monkeypatch):
         assert env_overrides["GOOGLE_APPLICATION_CREDENTIALS"] == _GOOGLE_ADC_CONTAINER_PATH
     finally:
         _cleanup_vertex_adc_file(creds_path)
-        assert not Path(creds_path).exists()
-        assert "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ
+    assert not Path(creds_path).exists()
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ
 

--- a/tests/sanity/test_providers.py
+++ b/tests/sanity/test_providers.py
@@ -6,6 +6,8 @@ Tests run for each provider configured via the provider_setup fixture:
   - OpenAI          — requires OPENAI_API_KEY, OPENAI_INFERENCE_MODEL
   - Azure OpenAI    — requires AZURE_OPENAI_BASE_URL, AZURE_OPENAI_API_KEY,
                                AZURE_OPENAI_INFERENCE_MODEL
+  - Vertex AI       — requires VERTEX_AI_CREDENTIALS, VERTEX_AI_PROJECT
+                      (default model google/gemini-2.5-pro)
 
 A provider is skipped automatically when its required variables are not set.
 
@@ -14,9 +16,12 @@ Examples:
     make test-sanity-granite          # Granite only
     make test-sanity-openai           # OpenAI only
     make test-sanity-azure            # Azure only
+    make test-sanity-vertexai         # Vertex AI only
 """
 
 import json
+import os
+from pathlib import Path
 
 import pytest
 import requests
@@ -168,3 +173,69 @@ class TestChatbotSanity:
         assert has_response_field, (
             f"Response should have one of {expected_fields}. Got: {list(response_data.keys())}"
         )
+
+
+@pytest.mark.vertexai
+def test_vertexai_run_config():
+    """Vertex AI sanity run configs must declare the provider, ADC project/location, and default model."""
+    sanity_dir = Path(__file__).parent
+    for name in ("vertexai-chatbot-run.yaml", "mcp-vertexai-chatbot-run.yaml"):
+        text = (sanity_dir / name).read_text()
+        assert "provider_id: vertexai" in text, name
+        assert "provider_type: remote::vertexai" in text, name
+        assert "project: ${env.VERTEX_AI_PROJECT:=}" in text, name
+        assert "location: ${env.VERTEX_AI_LOCATION:=global}" in text, name
+        assert "google/gemini-2.5-pro" in text, name
+
+
+@pytest.mark.vertexai
+def test_vertexai_provider_config_skipped_without_credentials(monkeypatch):
+    monkeypatch.delenv("VERTEX_AI_CREDENTIALS", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    monkeypatch.delenv("VERTEX_AI_PROJECT", raising=False)
+    from tests.sanity.conftest import _build_provider_config
+
+    with pytest.raises(pytest.skip.Exception, match="VERTEX_AI_CREDENTIALS"):
+        _build_provider_config("vertexai")
+
+
+@pytest.mark.vertexai
+def test_vertexai_provider_config_defaults(monkeypatch):
+    payload = '{"type":"service_account","project_id":"sanity-vertex-project"}'
+    monkeypatch.setenv("VERTEX_AI_CREDENTIALS", payload)
+    monkeypatch.setenv("VERTEX_AI_PROJECT", "sanity-vertex-project")
+    monkeypatch.delenv("VERTEX_AI_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("VERTEX_AI_LOCATION", raising=False)
+    monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)
+    from tests.sanity.conftest import (
+        _GOOGLE_ADC_CONTAINER_PATH,
+        _VERTEXAI_DEFAULT_MODEL,
+        _build_provider_config,
+        _cleanup_vertex_adc_file,
+        _google_adc_volume_mount,
+    )
+
+    run_config, env_overrides, config = _build_provider_config("vertexai")
+    creds_path = config.pop("credentials_file")
+    try:
+        assert run_config.endswith("vertexai-chatbot-run.yaml")
+        assert config == {"model": _VERTEXAI_DEFAULT_MODEL, "provider": "vertexai"}
+        assert Path(creds_path).is_file()
+        assert Path(creds_path).read_text() == payload
+        assert os.environ["GOOGLE_APPLICATION_CREDENTIALS"] == creds_path
+        assert env_overrides["GOOGLE_APPLICATION_CREDENTIALS"] == creds_path
+        assert env_overrides["VERTEX_AI_PROJECT"] == "sanity-vertex-project"
+        assert env_overrides["VERTEX_AI_INFERENCE_MODEL"] == _VERTEXAI_DEFAULT_MODEL
+        assert "VERTEX_AI_LOCATION" not in env_overrides
+        assert "VERTEX_AI_CREDENTIALS" not in env_overrides
+
+        mount = _google_adc_volume_mount(env_overrides)
+        assert mount is not None
+        assert mount.startswith(f"{Path(creds_path).resolve()}:")
+        assert mount.endswith(f"{_GOOGLE_ADC_CONTAINER_PATH}:ro,z")
+        assert env_overrides["GOOGLE_APPLICATION_CREDENTIALS"] == _GOOGLE_ADC_CONTAINER_PATH
+    finally:
+        _cleanup_vertex_adc_file(creds_path)
+        assert not Path(creds_path).exists()
+        assert "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ
+

--- a/tests/sanity/test_providers.py
+++ b/tests/sanity/test_providers.py
@@ -177,6 +177,8 @@ class TestChatbotSanity:
 
 def test_vertexai_run_config():
     """Vertex AI sanity run configs must declare the provider, ADC project/location, and default model."""
+    from tests.sanity.conftest import _VERTEXAI_DEFAULT_MODEL
+
     sanity_dir = Path(__file__).parent
     for name in ("vertexai-chatbot-run.yaml", "mcp-vertexai-chatbot-run.yaml"):
         text = (sanity_dir / name).read_text()
@@ -184,10 +186,9 @@ def test_vertexai_run_config():
         assert "provider_type: remote::vertexai" in text, name
         assert "project: ${env.VERTEX_AI_PROJECT:=}" in text, name
         assert "location: ${env.VERTEX_AI_LOCATION:=us-central1}" in text, name
-        assert "google/gemini-2.5-pro" in text, name
+        assert _VERTEXAI_DEFAULT_MODEL in text, name
 
 
-@pytest.mark.vertexai
 def test_vertexai_provider_config_skipped_without_credentials(monkeypatch):
     monkeypatch.delenv("VERTEX_AI_CREDENTIALS", raising=False)
     monkeypatch.delenv("GOOGLE_APPLICATION_CREDENTIALS", raising=False)

--- a/tests/sanity/vertexai-chatbot-run.yaml
+++ b/tests/sanity/vertexai-chatbot-run.yaml
@@ -1,0 +1,138 @@
+version: '2'
+image_name: ansible-chatbot-sanity-vertexai
+container_image: ansible-chatbot-sanity-vertexai
+apis:
+- inference
+- vector_io
+- safety
+- agents
+- datasetio
+- tool_runtime
+- files
+providers:
+  inference:
+  - provider_id: vertexai
+    provider_type: remote::vertexai
+    config:
+      project: ${env.VERTEX_AI_PROJECT:=}
+      location: ${env.VERTEX_AI_LOCATION:=global}
+  - provider_id: sentence-transformers
+    provider_type: inline::sentence-transformers
+    config: {}
+  vector_io:
+  - provider_id: aap_faiss
+    provider_type: inline::faiss
+    config:
+      persistence:
+        namespace: vector_io::faiss
+        backend: kv_rag
+  safety:
+  - provider_id: llama-guard
+    provider_type: inline::llama-guard
+    config:
+      excluded_categories: []
+  agents:
+  - provider_id: lightspeed_inline_agent
+    provider_type: inline::lightspeed_inline_agent
+    config:
+      persistence:
+        agent_state:
+          namespace: agents_state
+          backend: kv_default
+        responses:
+          table_name: agent_responses
+          backend: sql_default
+      tools_filter:
+        enabled: false
+  datasetio:
+  - provider_id: localfs
+    provider_type: inline::localfs
+    config:
+      kvstore:
+        namespace: localfs_datasetio
+        backend: kv_default
+  files:
+  - provider_id: meta-reference-files
+    provider_type: inline::localfs
+    config:
+      storage_dir: ${env.PROVIDERS_DB_DIR:=./test_data}/files
+      metadata_store:
+        table_name: files_metadata
+        backend: sql_default
+  tool_runtime:
+  - provider_id: rag-runtime
+    provider_type: inline::rag-runtime
+    config: {}
+storage:
+  backends:
+    kv_rag:
+      type: kv_sqlite
+      db_path: ${env.VECTOR_DB_DIR:=./test_data}/aap_faiss_store.db
+    kv_default:
+      type: kv_sqlite
+      db_path: ${env.KV_STORE_DB_DIR:=./test_data}/kv_store.db
+    sql_default:
+      type: sql_sqlite
+      db_path: ${env.SQL_STORE_DB_DIR:=./test_data}/sql_store.db
+  stores:
+    metadata:
+      namespace: registry
+      backend: kv_default
+    inference:
+      table_name: inference_store
+      backend: sql_default
+      max_write_queue_size: 10000
+      num_writers: 4
+    conversations:
+      table_name: openai_conversations
+      backend: sql_default
+    prompts:
+      namespace: prompts
+      backend: kv_default
+registered_resources:
+  models:
+    - metadata: {}
+      model_id: ${env.VERTEX_AI_INFERENCE_MODEL:=google/gemini-2.5-pro}
+      provider_id: vertexai
+      provider_model_id: ${env.VERTEX_AI_INFERENCE_MODEL:=google/gemini-2.5-pro}
+    - metadata:
+        embedding_dimension: 384
+      model_id: sentence-transformers/all-mpnet-base-v2
+      provider_id: sentence-transformers
+      provider_model_id: ${env.EMBEDDINGS_MODEL:=/.llama/data/embeddings_model}
+      model_type: embedding
+  shields: []
+  vector_stores:
+    - metadata: {}
+      vector_store_id: ${env.PROVIDER_VECTOR_DB_ID:=}
+      embedding_model: sentence-transformers/${env.EMBEDDINGS_MODEL:=/.llama/data/embeddings_model}
+      embedding_dimension: 384
+      provider_id: aap_faiss
+  datasets: []
+  scoring_fns: []
+  benchmarks: []
+  tool_groups:
+    - toolgroup_id: builtin::rag
+      provider_id: rag-runtime
+  safety:
+    - default_shield_id: llama-guard
+vector_stores:
+  default_provider_id: aap_faiss
+  default_embedding_model:
+    provider_id: sentence-transformers
+    model_id: /.llama/data/embeddings_model
+  annotation_prompt_params:
+    enable_annotations: true
+    annotation_instruction_template: >
+      When appropriate, cite sources at the end of sentences using doc_url and doc_title format.
+      Citing sources is not always required because citations are handled externally.
+      Never include any citation that is in the form '<| file-id |>'.
+logging: null
+server:
+  port: 8322
+  tls_certfile: null
+  tls_keyfile: null
+  tls_cafile: null
+  auth: null
+  disable_ipv6: false
+external_providers_dir: ${env.EXTERNAL_PROVIDERS_DIR:=/.llama/providers.d}

--- a/tests/sanity/vertexai-chatbot-run.yaml
+++ b/tests/sanity/vertexai-chatbot-run.yaml
@@ -15,7 +15,7 @@ providers:
     provider_type: remote::vertexai
     config:
       project: ${env.VERTEX_AI_PROJECT:=}
-      location: ${env.VERTEX_AI_LOCATION:=global}
+      location: ${env.VERTEX_AI_LOCATION:=us-central1}
   - provider_id: sentence-transformers
     provider_type: inline::sentence-transformers
     config: {}

--- a/uv.lock
+++ b/uv.lock
@@ -184,6 +184,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "cachetools" },
+    { name = "google-auth", extra = ["requests"] },
     { name = "kubernetes" },
     { name = "locust" },
     { name = "pre-commit" },
@@ -218,6 +219,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "cachetools", specifier = ">=6.1.0" },
+    { name = "google-auth", extras = ["requests"], specifier = ">=2.40.0" },
     { name = "kubernetes", specifier = ">=33.1.0" },
     { name = "locust", specifier = ">=2.39.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
@@ -674,7 +676,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -705,43 +707,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
 ]
 
 [[package]]
@@ -1152,6 +1154,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/7d/20606d1a4ae085eb3935e4d3625e7208911d0f1a0006c9fd962d88254d92/geventhttpclient-2.3.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:52516d5c153fcef0d3d2447e533244dc6360e8c2a190b958861137db6f227605", size = 115383, upload-time = "2026-03-03T08:08:49.454Z" },
     { url = "https://files.pythonhosted.org/packages/85/16/d20ac6ac73d63fe326ffe357a8e91c4f43b9e790faeeb9b15774eecf2550/geventhttpclient-2.3.9-cp314-cp314t-win32.whl", hash = "sha256:14eaa836bde26a70952e95ca462018f3a47c1c92642327315aa6502e54141016", size = 49749, upload-time = "2026-03-03T08:08:50.339Z" },
     { url = "https://files.pythonhosted.org/packages/59/f6/95d1ed1ace7902d8e1ce698db31931cb87d4abe621ec2df24e69daf49ae9/geventhttpclient-2.3.9-cp314-cp314t-win_amd64.whl", hash = "sha256:b9bbcbc7d5d875e5180f2b1f1c6fa8e092ef80d9debfb6ba22a4ec28f0565395", size = 50300, upload-time = "2026-03-03T08:08:51.482Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
 ]
 
 [[package]]
@@ -2057,7 +2077,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2096,7 +2116,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2108,7 +2128,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2138,9 +2158,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2152,7 +2172,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2682,6 +2702,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -184,7 +184,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "cachetools" },
-    { name = "google-auth", extra = ["requests"] },
     { name = "kubernetes" },
     { name = "locust" },
     { name = "pre-commit" },
@@ -219,7 +218,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "cachetools", specifier = ">=6.1.0" },
-    { name = "google-auth", extras = ["requests"], specifier = ">=2.40.0" },
     { name = "kubernetes", specifier = ">=33.1.0" },
     { name = "locust", specifier = ">=2.39.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
@@ -676,7 +674,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
@@ -707,43 +705,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cublas", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvjitlink", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
 ]
 
 [[package]]
@@ -1154,24 +1152,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/7d/20606d1a4ae085eb3935e4d3625e7208911d0f1a0006c9fd962d88254d92/geventhttpclient-2.3.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:52516d5c153fcef0d3d2447e533244dc6360e8c2a190b958861137db6f227605", size = 115383, upload-time = "2026-03-03T08:08:49.454Z" },
     { url = "https://files.pythonhosted.org/packages/85/16/d20ac6ac73d63fe326ffe357a8e91c4f43b9e790faeeb9b15774eecf2550/geventhttpclient-2.3.9-cp314-cp314t-win32.whl", hash = "sha256:14eaa836bde26a70952e95ca462018f3a47c1c92642327315aa6502e54141016", size = 49749, upload-time = "2026-03-03T08:08:50.339Z" },
     { url = "https://files.pythonhosted.org/packages/59/f6/95d1ed1ace7902d8e1ce698db31931cb87d4abe621ec2df24e69daf49ae9/geventhttpclient-2.3.9-cp314-cp314t-win_amd64.whl", hash = "sha256:b9bbcbc7d5d875e5180f2b1f1c6fa8e092ef80d9debfb6ba22a4ec28f0565395", size = 50300, upload-time = "2026-03-03T08:08:51.482Z" },
-]
-
-[[package]]
-name = "google-auth"
-version = "2.56.3"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cryptography" },
-    { name = "pyasn1-modules" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
-]
-
-[package.optional-dependencies]
-requests = [
-    { name = "requests" },
 ]
 
 [[package]]
@@ -2077,7 +2057,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -2116,7 +2096,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -2128,7 +2108,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -2158,9 +2138,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -2172,7 +2152,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -2702,18 +2682,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
-]
-
-[[package]]
-name = "pyasn1-modules"
-version = "0.4.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add sanity test coverage for the Vertex AI provider (`tests/sanity/test_providers.py`, `tests/sanity/mcp-vertexai-chatbot-run.yaml`, `tests/sanity/vertexai-chatbot-run.yaml`)
- Update `tests/sanity/conftest.py` and CI workflow to support the new provider
- Update `uv.lock` for related dependency changes

## Test plan
- [ ] CI sanity test suite passes for the new Vertex AI provider job