### PR TITLE
test: dump chatbot logs on MCP sanity 500s

### DIFF
--- a/tests/sanity/test_mcp.py
+++ b/tests/sanity/test_mcp.py
@@ -80,20 +80,27 @@ def _post_query(base_url, provider_setup, query, timeout=180, conversation_id=No
 
 
 def _dump_query_failure(provider_setup, response, lines=80):
-    """Write the 500 body and recent chatbot logs so the filter-LLM exception is visible."""
-    sys.stderr.write(
+    """Write the 5xx body and recent chatbot logs so the filter-LLM exception is visible."""
+    encoding = sys.stderr.encoding or "utf-8"
+
+    def _write(text):
+        sys.stderr.write(text.encode(encoding, errors="replace").decode(encoding))
+
+    body = response.text
+    if len(body) > 5000:
+        body = f"{body[:5000]}\n... [truncated, {len(body)} chars total]"
+    _write(
         f"\n[✗] POST /v1/query returned {response.status_code} "
         f"for provider={provider_setup.get('provider')!r} "
         f"model={provider_setup.get('model')!r}\n"
-        f"[✗] Response body:\n{response.text}\n"
+        f"[✗] Response body:\n{body}\n"
     )
     output_lines = provider_setup.get("output_lines") or []
-    with _CHATBOT_OUTPUT_LOCK:
-        tail = list(output_lines[-lines:])
+    tail = _lines_from(output_lines, -lines) if lines > 0 else []
     if tail:
-        sys.stderr.write(f"[✗] Last {len(tail)} chatbot container log lines:\n")
+        _write(f"[✗] Last {len(tail)} chatbot container log lines:\n")
         for line in tail:
-            sys.stderr.write(line + "\n")
+            _write(line + "\n")
     sys.stderr.flush()
 
 

--- a/tests/sanity/test_mcp.py
+++ b/tests/sanity/test_mcp.py
@@ -22,6 +22,7 @@ import ast
 import json
 import os
 import socket
+import sys
 import warnings
 
 import pytest
@@ -67,12 +68,33 @@ def _post_query(base_url, provider_setup, query, timeout=180, conversation_id=No
     }
     if conversation_id:
         payload["conversation_id"] = conversation_id
-    return requests.post(
+    response = requests.post(
         f"{base_url}/v1/query",
         json=payload,
         headers=_query_headers(),
         timeout=timeout,
     )
+    if response.status_code >= 500:
+        _dump_query_failure(provider_setup, response)
+    return response
+
+
+def _dump_query_failure(provider_setup, response, lines=80):
+    """Write the 500 body and recent chatbot logs so the filter-LLM exception is visible."""
+    sys.stderr.write(
+        f"\n[✗] POST /v1/query returned {response.status_code} "
+        f"for provider={provider_setup.get('provider')!r} "
+        f"model={provider_setup.get('model')!r}\n"
+        f"[✗] Response body:\n{response.text}\n"
+    )
+    output_lines = provider_setup.get("output_lines") or []
+    with _CHATBOT_OUTPUT_LOCK:
+        tail = list(output_lines[-lines:])
+    if tail:
+        sys.stderr.write(f"[✗] Last {len(tail)} chatbot container log lines:\n")
+        for line in tail:
+            sys.stderr.write(line + "\n")
+    sys.stderr.flush()
 
 
 def _response_text(response_data):


### PR DESCRIPTION
<!-- This PR does not need a corresponding Jira item. -->

## Description
When an MCP sanity test hits `POST /v1/query` and the chatbot returns HTTP 500, pytest currently only sees the status code. This change dumps the response body and the last 80 chatbot container log lines to stderr so filter-LLM / Lightspeed exceptions are visible in CI and local runs.

## Testing
### Steps to test
1. Pull down the PR
2. Run MCP sanity tests against a setup that produces a 500 from `/v1/query` (or inspect the new `_dump_query_failure` path in `tests/sanity/test_mcp.py`)
3. Confirm pytest output includes the response body and recent chatbot container logs

### Scenarios tested
Not re-run in this commit; debug aid only.

## Production deployment
- [x] This code change is ready for production on its own
- [ ] This code change requires the following considerations before going to production:

## Test plan
- [ ] Run MCP sanity tests and confirm 500s print chatbot logs
- [ ] Confirm non-500 queries are unchanged


Made with [Cursor](https://cursor.com)